### PR TITLE
Implement reaction insights, attachments, and 2025 settings redesign

### DIFF
--- a/lib/menu/feed_section.dart
+++ b/lib/menu/feed_section.dart
@@ -1014,7 +1014,9 @@ mixin _FeedSection on State<MenuScreen> {
   String _normalizeUploadUrl(String? url) {
     if (url == null || url.isEmpty) return '';
     if (url.startsWith('http')) return url;
-    return ApiService.uploadBaseUrl + url;
+    final base = ApiService.uploadBaseUrl;
+    final needsSlash = !url.startsWith('/');
+    return needsSlash ? '$base/$url' : '$base$url';
   }
 
   _PostContentParts _parsePostContent(String? raw) {
@@ -1027,10 +1029,11 @@ mixin _FeedSection on State<MenuScreen> {
     String? activity;
     String? checkIn;
     String? vibe;
-    final metaPattern = RegExp(r'^•\\s*(.+?):\\s*(.+)\$', caseSensitive: false);
+    final metaPattern = RegExp(r'^(?:[\\u2022\\-*]\\s*)?(.+?):\\s*(.+)\$', caseSensitive: false);
     for (final line in lines) {
       final trimmed = line.trim();
-      final match = metaPattern.firstMatch(trimmed);
+      final sanitized = trimmed.replaceFirst(RegExp(r'^[\\u2022\\-*]\\s*'), '');
+      final match = metaPattern.firstMatch(trimmed) ?? metaPattern.firstMatch(sanitized);
       if (match != null) {
         final key = match.group(1)!.toLowerCase();
         final value = match.group(2)!.trim();
@@ -1045,8 +1048,9 @@ mixin _FeedSection on State<MenuScreen> {
         }
         continue;
       }
-      if (trimmed.startsWith('• Vibe palette')) {
-        vibe = trimmed.replaceFirst('•', '').trim();
+      final lower = sanitized.toLowerCase();
+      if (lower.startsWith('vibe palette') || lower.startsWith('vibe:')) {
+        vibe = sanitized;
         continue;
       }
       bodyLines.add(line);
@@ -1229,7 +1233,7 @@ mixin _FeedSection on State<MenuScreen> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               _postHeader(context, post, parts),
-              if (bodyText.isNotEmpty) ...[
+              if (bodyText.isNotEmpty || vibePalette != null) ...[
                 const SizedBox(height: 12),
                 _PostBodyBlock(text: bodyText, palette: vibePalette),
               ],
@@ -1273,25 +1277,16 @@ mixin _FeedSection on State<MenuScreen> {
     final sticker = _stickerProviderFor(user?['sticker'] ?? user?['avatar_sticker']);
     final createdAt = post['created_at'] as String?;
     final visibility = post['visibility'] as String? ?? 'public';
-    final chips = <Widget>[];
     final timeAgo = _timeAgo(createdAt);
-    if (timeAgo.isNotEmpty) {
-      chips.add(
-        _PostMetaInfoChip(
-          icon: Icons.access_time,
-          label: timeAgo,
-          trailing: Icon(_visibilityIcon(visibility), size: 14, color: theme.hintColor),
-        ),
-      );
-    }
+    final metaPills = <Widget>[];
     if (parts.mood != null && parts.mood!.isNotEmpty) {
-      chips.add(_PostMetaPill(icon: Icons.emoji_emotions_outlined, label: parts.mood!, color: theme.colorScheme.primary));
+      metaPills.add(_PostMetaPill(icon: Icons.emoji_emotions_outlined, label: parts.mood!, color: theme.colorScheme.primary));
     }
     if (parts.activity != null && parts.activity!.isNotEmpty) {
-      chips.add(_PostMetaPill(icon: Icons.flash_on, label: parts.activity!, color: theme.colorScheme.secondary));
+      metaPills.add(_PostMetaPill(icon: Icons.flash_on, label: parts.activity!, color: theme.colorScheme.secondary));
     }
     if (parts.checkIn != null && parts.checkIn!.isNotEmpty) {
-      chips.add(_PostMetaPill(icon: Icons.place_outlined, label: parts.checkIn!, color: theme.colorScheme.tertiary));
+      metaPills.add(_PostMetaPill(icon: Icons.place_outlined, label: parts.checkIn!, color: theme.colorScheme.tertiary));
     }
 
     return Row(
@@ -1310,13 +1305,23 @@ mixin _FeedSection on State<MenuScreen> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(displayName, style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600)),
-              const SizedBox(height: 6),
-              Wrap(
-                spacing: 8,
-                runSpacing: 6,
-                crossAxisAlignment: WrapCrossAlignment.center,
-                children: chips,
-              ),
+              if (timeAgo.isNotEmpty) ...[
+                const SizedBox(height: 6),
+                _PostMetaInfoChip(
+                  icon: Icons.access_time,
+                  label: timeAgo,
+                  trailing: Icon(_visibilityIcon(visibility), size: 14, color: theme.hintColor),
+                ),
+              ],
+              if (metaPills.isNotEmpty) ...[
+                const SizedBox(height: 6),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 6,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: metaPills,
+                ),
+              ],
             ],
           ),
         ),
@@ -3527,37 +3532,67 @@ class _PostBodyBlock extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final hasPalette = palette != null && palette!.isNotEmpty;
+    final colors = hasPalette
+        ? palette!
+            .map((color) =>
+                theme.brightness == Brightness.light ? Color.alphaBlend(Colors.white.withOpacity(0.42), color) : color)
+            .toList(growable: false)
+        : null;
     final decoration = BoxDecoration(
       borderRadius: BorderRadius.circular(20),
       gradient: hasPalette
-          ? LinearGradient(colors: palette!, begin: Alignment.topLeft, end: Alignment.bottomRight)
+          ? LinearGradient(colors: colors!, begin: Alignment.topLeft, end: Alignment.bottomRight)
           : null,
-      color: hasPalette ? null : Colors.white.withOpacity(0.05),
-      border: Border.all(color: Colors.white.withOpacity(hasPalette ? 0.18 : 0.08)),
+      color: hasPalette ? null : theme.colorScheme.surfaceVariant.withOpacity(0.18),
+      border: Border.all(
+        color: hasPalette
+            ? (theme.brightness == Brightness.light
+                ? Colors.black.withOpacity(0.04)
+                : Colors.white.withOpacity(0.18))
+            : Colors.white.withOpacity(0.08),
+      ),
       boxShadow: hasPalette
           ? [
               BoxShadow(
-                color: palette!.last.withOpacity(0.25),
+                color: (theme.brightness == Brightness.light ? colors!.last : colors!.last).withOpacity(0.22),
+                blurRadius: 24,
+                offset: const Offset(0, 16),
+              ),
+            ]
+          : [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.08),
                 blurRadius: 20,
                 offset: const Offset(0, 12),
               ),
-            ]
-          : null,
+            ],
     );
 
     final textStyle = hasPalette
         ? theme.textTheme.bodyMedium?.copyWith(
-              color: Colors.white,
+              color: theme.brightness == Brightness.light ? Colors.black.withOpacity(0.85) : Colors.white,
               height: 1.5,
-              fontWeight: FontWeight.w500,
+              fontWeight: FontWeight.w600,
             )
         : theme.textTheme.bodyMedium?.copyWith(height: 1.5);
 
+    final trimmed = text.trim();
+    final child = trimmed.isEmpty
+        ? const SizedBox(height: 72)
+        : Text(
+            text,
+            style: textStyle,
+          );
+
+    final padding = trimmed.isEmpty
+        ? const EdgeInsets.symmetric(horizontal: 18, vertical: 24)
+        : const EdgeInsets.symmetric(horizontal: 18, vertical: 16);
+
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 16),
+      padding: padding,
       decoration: decoration,
-      child: Text(text, style: textStyle),
+      child: child,
     );
   }
 }

--- a/lib/menu/feed_section.dart
+++ b/lib/menu/feed_section.dart
@@ -1029,10 +1029,13 @@ mixin _FeedSection on State<MenuScreen> {
     String? activity;
     String? checkIn;
     String? vibe;
-    final metaPattern = RegExp(r'^(?:[\\u2022\\-*]\\s*)?(.+?):\\s*(.+)\$', caseSensitive: false);
+    final metaPattern = RegExp(
+      r'^(?:[-•*]\s*)?([^:]+):\s*(.+)$',
+      caseSensitive: false,
+    );
     for (final line in lines) {
       final trimmed = line.trim();
-      final sanitized = trimmed.replaceFirst(RegExp(r'^[\\u2022\\-*]\\s*'), '');
+      final sanitized = trimmed.replaceFirst(RegExp(r'^[-•*]\s*'), '');
       final match = metaPattern.firstMatch(trimmed) ?? metaPattern.firstMatch(sanitized);
       if (match != null) {
         final key = match.group(1)!.toLowerCase();

--- a/lib/menu/feed_section.dart
+++ b/lib/menu/feed_section.dart
@@ -1,0 +1,3563 @@
+part of menu_screen;
+
+const List<String> _kReactionOrder = ['like', 'love', 'care', 'wow', 'haha', 'sad', 'angry'];
+
+const Map<String, _ReactionVisual> _kReactionVisuals = {
+  'like': _ReactionVisual(Icons.thumb_up_alt_rounded, Color(0xFF4C8BF5), 'reaction_like'),
+  'love': _ReactionVisual(Icons.favorite_rounded, Color(0xFFFF5C8A), 'reaction_love'),
+  'care': _ReactionVisual(Icons.emoji_emotions_rounded, Color(0xFFFFB74D), 'reaction_care'),
+  'wow': _ReactionVisual(Icons.auto_awesome_rounded, Color(0xFF7E57C2), 'reaction_wow'),
+  'haha': _ReactionVisual(Icons.mood_rounded, Color(0xFFFFD54F), 'reaction_haha'),
+  'sad': _ReactionVisual(Icons.sentiment_dissatisfied_rounded, Color(0xFF4FC3F7), 'reaction_sad'),
+  'angry': _ReactionVisual(Icons.sentiment_very_dissatisfied_rounded, Color(0xFFF06292), 'reaction_angry'),
+};
+
+const List<List<Color>> _kVibePalettes = [
+  [Color(0xFF4A00E0), Color(0xFF8E2DE2)],
+  [Color(0xFF00B4DB), Color(0xFF0083B0)],
+  [Color(0xFFFF512F), Color(0xFFF09819)],
+  [Color(0xFF11998E), Color(0xFF38EF7D)],
+  [Color(0xFF4568DC), Color(0xFFB06AB3)],
+];
+
+const String _kCommentAttachmentPrefix = '::attachment::';
+
+_ReactionVisual _visualForReaction(String type) =>
+    _kReactionVisuals[type] ?? _kReactionVisuals['like']!;
+
+String _reactionLabel(BuildContext context, String type) =>
+    I18n.t(context, _visualForReaction(type).labelKey);
+
+int _totalReactions(Map<String, int>? counts) {
+  if (counts == null || counts.isEmpty) return 0;
+  return counts.values.fold<int>(0, (sum, value) => sum + value);
+}
+
+List<MapEntry<String, int>> _topReactions(Map<String, int> counts) {
+  final filtered = counts.entries.where((e) => e.value > 0).toList();
+  filtered.sort((a, b) {
+    final orderA = _kReactionOrder.contains(a.key) ? _kReactionOrder.indexOf(a.key) : _kReactionOrder.length;
+    final orderB = _kReactionOrder.contains(b.key) ? _kReactionOrder.indexOf(b.key) : _kReactionOrder.length;
+    final orderCompare = orderA.compareTo(orderB);
+    if (a.value == b.value) {
+      return orderCompare;
+    }
+    return b.value.compareTo(a.value);
+  });
+  return filtered;
+}
+
+Map<String, int> _countsFromDynamic(dynamic raw) {
+  final result = <String, int>{};
+  if (raw is Map) {
+    for (final entry in raw.entries) {
+      final key = entry.key?.toString();
+      final value = entry.value;
+      if (key == null) continue;
+      if (value is num) {
+        result[key] = value.toInt();
+      }
+    }
+  }
+  return result;
+}
+
+class _ReactionVisual {
+  const _ReactionVisual(this.icon, this.color, this.labelKey);
+
+  final IconData icon;
+  final Color color;
+  final String labelKey;
+}
+
+enum ComposerIntent { mood, tagFriends, checkIn, goLive, image }
+
+class _PostContentParts {
+  const _PostContentParts({
+    required this.text,
+    this.mood,
+    this.activity,
+    this.checkIn,
+    this.vibe,
+  });
+
+  final String text;
+  final String? mood;
+  final String? activity;
+  final String? checkIn;
+  final String? vibe;
+
+  bool get hasMeta =>
+      (mood != null && mood!.isNotEmpty) ||
+      (activity != null && activity!.isNotEmpty) ||
+      (checkIn != null && checkIn!.isNotEmpty);
+}
+
+mixin _FeedSection on State<MenuScreen> {
+  /// Feed state with PHP-backed reactions, comments, and glass UI.
+  final List<Map<String, dynamic>> _posts = [];
+  bool _loadingPosts = false;
+  final Map<int, Map<String, int>> _reactionCounts = {};
+  final Map<int, String?> _userReactions = {};
+  final Map<int, int> _commentCounts = {};
+  final ScrollController _feedCtrl = ScrollController();
+  int? _currentUserId;
+  Future<_ComposerAvatar>? _composerAvatarFuture;
+
+  void initFeed() {
+    _fetchPosts();
+    _hydrateCurrentUser();
+    _composerAvatarFuture = _loadAvatarForComposer(refresh: true);
+  }
+
+  void disposeFeed() {
+    _feedCtrl.dispose();
+  }
+
+  Future<void> _hydrateCurrentUser() async {
+    final sp = await SharedPreferences.getInstance();
+    if (!mounted) return;
+    setState(() {
+      _currentUserId = sp.getInt('auth_user_id');
+    });
+  }
+
+  int? _asInt(dynamic value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    return int.tryParse(value?.toString() ?? '');
+  }
+
+  List<Widget> buildHomeActions(BuildContext context) {
+    final iconColor = Theme.of(context).colorScheme.onSurface;
+    Widget circle(IconData icon, {VoidCallback? onTap}) => Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(18),
+            child: BackdropFilter(
+              filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+              child: Material(
+                color: Colors.white.withOpacity(0.08),
+                child: InkWell(
+                  onTap: onTap,
+                  borderRadius: BorderRadius.circular(18),
+                  child: Padding(
+                    padding: const EdgeInsets.all(10),
+                    child: Icon(icon, size: 18, color: iconColor),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+    return [
+      circle(Icons.add_box_outlined, onTap: () => _toast(context, I18n.t(context, 'create'))),
+      circle(Icons.search, onTap: () => _toast(context, I18n.t(context, 'search'))),
+      circle(Icons.message_outlined, onTap: () => _toast(context, I18n.t(context, 'messages'))),
+      const SizedBox(width: 6),
+    ];
+  }
+
+  Widget _buildFeed(BuildContext context, ThemeData theme) {
+    final width = MediaQuery.of(context).size.width;
+    final isCompact = width < 700;
+
+    final children = <Widget>[
+      if (!isCompact) _homeTopBar(context),
+      const SizedBox(height: 8),
+      _homeComposer(context),
+      const Divider(height: 24),
+      if (_loadingPosts)
+        ...List.generate(4, (_) => const SkeletonPostCard()).expand((w) => [w, const SizedBox(height: 12)]),
+      if (!_loadingPosts && _posts.isEmpty)
+        Padding(
+          padding: const EdgeInsets.all(24),
+          child: Center(child: Text('Nu exista', style: theme.textTheme.bodyMedium)),
+        ),
+      if (!_loadingPosts && _posts.isNotEmpty)
+        ..._posts.map((p) => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              child: _postCard(context, p),
+            )),
+    ];
+
+    return RefreshIndicator(
+      onRefresh: _fetchPosts,
+      child: ListView(
+        controller: _feedCtrl,
+        padding: EdgeInsets.zero,
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: children,
+      ),
+    );
+  }
+
+  void _toast(BuildContext context, String msg) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(msg), duration: const Duration(milliseconds: 900)),
+    );
+  }
+
+  Widget _homeTopBar(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Row(
+        children: [
+          Text('Aplicatie', style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700)),
+          const Spacer(),
+          ...buildHomeActions(context),
+        ],
+      ),
+    );
+  }
+
+  Widget _homeComposer(BuildContext context) {
+    final theme = Theme.of(context);
+
+    Widget composerChip(String label, IconData icon, {ComposerIntent? intent}) {
+      return GestureDetector(
+        onTap: () => _openCreatePost(context, intent: intent),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.08),
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(color: Colors.white.withOpacity(0.12)),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 16, color: theme.colorScheme.primary),
+              const SizedBox(width: 6),
+              Text(label, style: theme.textTheme.labelMedium),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: FutureBuilder<_ComposerAvatar>(
+        future: _composerAvatarFuture ??= _loadAvatarForComposer(),
+        builder: (context, snap) {
+          final data = snap.data;
+          return ClipRRect(
+            borderRadius: BorderRadius.circular(24),
+            child: BackdropFilter(
+              filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+              child: Container(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      theme.colorScheme.surface.withOpacity(0.88),
+                      theme.colorScheme.surface.withOpacity(0.62),
+                    ],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                  borderRadius: BorderRadius.circular(24),
+                  border: Border.all(color: theme.colorScheme.primary.withOpacity(0.08)),
+                ),
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        FramedAvatar(
+                          image: data?.img,
+                          name: data?.initials ?? '🙂',
+                          radius: 18,
+                          frameStyle: data?.frame ?? 'none',
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: GestureDetector(
+                            onTap: () => _openCreatePost(context),
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                              decoration: BoxDecoration(
+                                color: Colors.white.withOpacity(0.08),
+                                borderRadius: BorderRadius.circular(18),
+                                border: Border.all(color: Colors.white.withOpacity(0.12)),
+                              ),
+                              child: Text(
+                                I18n.t(context, 'whats_on_your_mind'),
+                                style: theme.textTheme.bodyMedium?.copyWith(color: theme.hintColor),
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Container(
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              colors: [
+                                theme.colorScheme.primary,
+                                theme.colorScheme.primary.withOpacity(0.75),
+                              ],
+                              begin: Alignment.topLeft,
+                              end: Alignment.bottomRight,
+                            ),
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          child: IconButton(
+                            onPressed: () => _openCreatePost(context, intent: ComposerIntent.image),
+                            icon: const Icon(Icons.image_outlined, color: Colors.white),
+                            splashRadius: 22,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 14),
+                    Wrap(
+                      spacing: 10,
+                      runSpacing: 10,
+                      children: [
+                        composerChip(
+                          I18n.t(context, 'feeling_activity'),
+                          Icons.auto_awesome,
+                          intent: ComposerIntent.mood,
+                        ),
+                        composerChip(
+                          I18n.t(context, 'tag_friends'),
+                          Icons.people_alt_outlined,
+                          intent: ComposerIntent.tagFriends,
+                        ),
+                        composerChip(
+                          I18n.t(context, 'check_in'),
+                          Icons.place_outlined,
+                          intent: ComposerIntent.checkIn,
+                        ),
+                        composerChip(
+                          I18n.t(context, 'go_live'),
+                          Icons.videocam_outlined,
+                          intent: ComposerIntent.goLive,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _fetchPosts() async {
+    if (!mounted) return;
+    setState(() => _loadingPosts = true);
+    try {
+      final api = ApiService();
+      final list = await api.getPosts(limit: 20, offset: 0);
+      final normalized = <Map<String, dynamic>>[];
+      for (final item in list) {
+        normalized.add(_normalizePostRecord(item));
+      }
+      if (!mounted) return;
+      setState(() {
+        _posts
+          ..clear()
+          ..addAll(normalized);
+        _loadingPosts = false;
+      });
+      for (final p in list) {
+        final pid = (p['id'] as num?)?.toInt();
+        if (pid != null) {
+          unawaited(_refreshReactionsFor(pid));
+          unawaited(_ensureCommentsCount(pid));
+        }
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _loadingPosts = false);
+      _toast(context, 'Nu s-au putut încărca postările');
+    }
+  }
+
+  Map<String, dynamic> _normalizePostRecord(dynamic raw) {
+    final map = <String, dynamic>{};
+    if (raw is Map) {
+      raw.forEach((key, value) {
+        if (key == null) return;
+        map[key.toString()] = value;
+      });
+    }
+
+    Map<String, dynamic> ensureMap(dynamic value) {
+      if (value is Map<String, dynamic>) {
+        return Map<String, dynamic>.from(value);
+      }
+      if (value is Map) {
+        return value.map((k, v) => MapEntry(k.toString(), v));
+      }
+      return <String, dynamic>{};
+    }
+
+    String? clean(dynamic value) {
+      if (value == null) return null;
+      final text = value.toString().trim();
+      return text.isEmpty ? null : text;
+    }
+
+    final user = ensureMap(map['user']);
+    final id = _asInt(user['id']) ?? _asInt(map['user_id']);
+    if (id != null) {
+      user['id'] = id;
+    }
+
+    final nameCandidates = <String?>[
+      clean(user['full_name']),
+      clean(user['name']),
+      clean(map['user_name']),
+      clean(map['full_name']),
+      clean(map['username']),
+    ];
+    final resolvedName = nameCandidates.firstWhere(
+      (element) => element != null && element.isNotEmpty,
+      orElse: () => null,
+    );
+    if (resolvedName != null) {
+      user.putIfAbsent('full_name', () => resolvedName);
+      user.putIfAbsent('name', () => resolvedName);
+      user.putIfAbsent('username', () => resolvedName);
+    }
+
+    final avatarCandidates = <String?>[
+      clean(user['avatar']),
+      clean(map['user_avatar']),
+      clean(map['avatar']),
+      clean(map['avatar_url']),
+    ];
+    final resolvedAvatar = avatarCandidates.firstWhere(
+      (element) => element != null && element.isNotEmpty,
+      orElse: () => null,
+    );
+    if (resolvedAvatar != null) {
+      user['avatar'] = resolvedAvatar;
+    }
+
+    final frameCandidates = <String?>[
+      clean(user['frame']),
+      clean(map['user_frame']),
+      clean(map['avatar_frame']),
+    ];
+    final resolvedFrame = frameCandidates.firstWhere(
+      (element) => element != null && element.isNotEmpty,
+      orElse: () => null,
+    );
+    if (resolvedFrame != null) {
+      user['frame'] = resolvedFrame;
+    }
+
+    final stickerCandidates = <String?>[
+      clean(user['sticker']),
+      clean(map['user_sticker']),
+      clean(map['avatar_sticker']),
+    ];
+    final resolvedSticker = stickerCandidates.firstWhere(
+      (element) => element != null && element.isNotEmpty,
+      orElse: () => null,
+    );
+    if (resolvedSticker != null) {
+      user['sticker'] = resolvedSticker;
+    }
+
+    if (clean(user['name']) == null && id != null) {
+      user['name'] = 'User #$id';
+      user.putIfAbsent('full_name', () => 'User #$id');
+      user.putIfAbsent('username', () => 'user$id');
+    }
+
+    map['user'] = user;
+    return map;
+  }
+
+  Future<void> _openCreatePost(BuildContext context,
+      {Map<String, dynamic>? existing, ComposerIntent? intent}) async {
+    final sp = await SharedPreferences.getInstance();
+    final token = sp.getString('auth_token');
+    if (token == null) {
+      _toast(context, I18n.t(context, 'not_authenticated'));
+      return;
+    }
+    final isEdit = existing != null;
+    final parsedContent = _parsePostContent(existing?['content'] as String?);
+    final controller = TextEditingController(text: parsedContent.text);
+    final theme = Theme.of(context);
+    XFile? pickedMedia;
+    String? pickedGifUrl;
+    final existingImageUrl = existing?['image_url'] as String?;
+    bool checkInLoading = false;
+    bool autoCheckInHandled = intent != ComposerIntent.checkIn;
+
+    final gradients = _kVibePalettes;
+    final feelings = <String>['Inspired', 'Celebrating', 'Chill', 'Focused'];
+    final activities = <String>['Working remotely', 'Traveling', 'Gaming session', 'Coffee break'];
+    int? selectedGradient = _vibeIndexFromMeta(parsedContent.vibe, gradients.length);
+    String? selectedFeeling = parsedContent.mood;
+    String? selectedActivity = parsedContent.activity;
+    String? selectedCheckIn = parsedContent.checkIn;
+
+    if (intent == ComposerIntent.goLive && controller.text.trim().isEmpty) {
+      controller.text = 'Going live soon! 🔴';
+    }
+    if (intent == ComposerIntent.tagFriends && controller.text.trim().isEmpty) {
+      controller.text = '@';
+      controller.selection = TextSelection.fromPosition(TextPosition(offset: controller.text.length));
+    }
+    if (intent == ComposerIntent.mood && selectedFeeling == null && feelings.isNotEmpty) {
+      selectedFeeling = feelings.first;
+    }
+
+    final result = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) {
+        final bottom = MediaQuery.of(ctx).viewInsets.bottom;
+        return Padding(
+          padding: EdgeInsets.only(bottom: bottom),
+          child: StatefulBuilder(builder: (ctx2, setSheetState) {
+            if (!autoCheckInHandled) {
+              autoCheckInHandled = true;
+              Future.microtask(() async {
+                setSheetState(() => checkInLoading = true);
+                final location = await _resolveCurrentLocationName();
+                if (!mounted) return;
+                setSheetState(() {
+                  checkInLoading = false;
+                  if (location != null) {
+                    selectedCheckIn = location;
+                  } else {
+                    _toast(context, I18n.t(context, 'location_fetch_failed'));
+                  }
+                });
+              });
+            }
+            final canPublish = controller.text.trim().isNotEmpty;
+            final hasNewAttachment = pickedMedia != null || pickedGifUrl != null;
+            final showExistingAttachment =
+                !hasNewAttachment && isEdit && (existingImageUrl != null && existingImageUrl.isNotEmpty);
+            return ClipRRect(
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+                child: Container(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [
+                        theme.colorScheme.surface.withOpacity(0.95),
+                        theme.colorScheme.surface.withOpacity(0.8),
+                      ],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
+                    border: Border.all(color: theme.colorScheme.primary.withOpacity(0.08)),
+                  ),
+                  padding: const EdgeInsets.fromLTRB(20, 18, 20, 20),
+                  child: SafeArea(
+                    top: false,
+                    child: SingleChildScrollView(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Center(
+                            child: Container(
+                              width: 46,
+                              height: 4,
+                              decoration: BoxDecoration(
+                                color: Colors.white.withOpacity(0.24),
+                                borderRadius: BorderRadius.circular(2),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Center(
+                                  child: Text(
+                                    isEdit ? I18n.t(context, 'edit_post') : I18n.t(context, 'create_post'),
+                                    style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                                  ),
+                                ),
+                              ),
+                              IconButton(
+                                tooltip: I18n.t(context, 'close'),
+                                onPressed: () => Navigator.pop(ctx, false),
+                                icon: const Icon(Icons.close),
+                              )
+                            ],
+                          ),
+                          const SizedBox(height: 16),
+                          AnimatedContainer(
+                            duration: const Duration(milliseconds: 200),
+                            decoration: BoxDecoration(
+                              gradient: selectedGradient != null
+                                  ? LinearGradient(
+                                      colors: gradients[selectedGradient!],
+                                      begin: Alignment.topLeft,
+                                      end: Alignment.bottomRight,
+                                    )
+                                  : null,
+                              color: selectedGradient == null
+                                  ? theme.colorScheme.surfaceVariant.withOpacity(0.35)
+                                  : null,
+                              borderRadius: BorderRadius.circular(18),
+                              border: Border.all(color: Colors.white.withOpacity(0.12)),
+                            ),
+                            child: TextField(
+                              controller: controller,
+                              onChanged: (_) => setSheetState(() {}),
+                              maxLines: 6,
+                              minLines: 3,
+                              style: (selectedGradient != null)
+                                  ? theme.textTheme.bodyLarge?.copyWith(color: Colors.white)
+                                  : theme.textTheme.bodyLarge,
+                              decoration: InputDecoration(
+                                hintText: I18n.t(context, 'share_something'),
+                                border: InputBorder.none,
+                                contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          Text('Background vibe', style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600)),
+                          const SizedBox(height: 8),
+                          Wrap(
+                            spacing: 12,
+                            children: List.generate(gradients.length, (index) {
+                              final colors = gradients[index];
+                              final selected = selectedGradient == index;
+                              return GestureDetector(
+                                onTap: () => setSheetState(() {
+                                  selectedGradient = selected ? null : index;
+                                }),
+                                child: Container(
+                                  width: 36,
+                                  height: 36,
+                                  decoration: BoxDecoration(
+                                    gradient: LinearGradient(colors: colors, begin: Alignment.topLeft, end: Alignment.bottomRight),
+                                    shape: BoxShape.circle,
+                                    border: Border.all(
+                                      color: selected ? theme.colorScheme.primary : Colors.white54,
+                                      width: selected ? 2.4 : 1.2,
+                                    ),
+                                    boxShadow: selected
+                                        ? [
+                                            BoxShadow(
+                                              color: theme.colorScheme.primary.withOpacity(0.4),
+                                              blurRadius: 10,
+                                              offset: const Offset(0, 4),
+                                            ),
+                                          ]
+                                        : null,
+                                  ),
+                                  child: selected
+                                      ? const Icon(Icons.check, size: 18, color: Colors.white)
+                                      : null,
+                                ),
+                              );
+                            }),
+                          ),
+                          const SizedBox(height: 18),
+                          Text('Mood highlight', style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600)),
+                          const SizedBox(height: 8),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 6,
+                            children: feelings.map((feeling) {
+                              final selected = selectedFeeling == feeling;
+                              return ChoiceChip(
+                                label: Text(feeling),
+                                selected: selected,
+                                onSelected: (value) => setSheetState(() => selectedFeeling = value ? feeling : null),
+                                selectedColor: theme.colorScheme.primary.withOpacity(0.25),
+                                backgroundColor: Colors.white.withOpacity(0.08),
+                                labelStyle: theme.textTheme.labelMedium?.copyWith(
+                                  color: selected ? theme.colorScheme.primary : theme.hintColor,
+                                ),
+                                side: BorderSide(color: selected ? theme.colorScheme.primary : Colors.white24),
+                              );
+                            }).toList(),
+                          ),
+                          const SizedBox(height: 18),
+                          Text('Activity', style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600)),
+                          const SizedBox(height: 8),
+                          Wrap(
+                            spacing: 8,
+                            runSpacing: 6,
+                            children: activities.map((activity) {
+                              final selected = selectedActivity == activity;
+                              return ChoiceChip(
+                                label: Text(activity),
+                                selected: selected,
+                                onSelected: (value) => setSheetState(() => selectedActivity = value ? activity : null),
+                                selectedColor: theme.colorScheme.secondary.withOpacity(0.25),
+                                backgroundColor: Colors.white.withOpacity(0.08),
+                                labelStyle: theme.textTheme.labelMedium?.copyWith(
+                                  color: selected ? theme.colorScheme.secondary : theme.hintColor,
+                                ),
+                                side: BorderSide(color: selected ? theme.colorScheme.secondary : Colors.white24),
+                              );
+                            }).toList(),
+                          ),
+                          const SizedBox(height: 18),
+                          Text(
+                            I18n.t(context, 'check_in'),
+                            style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+                          ),
+                          const SizedBox(height: 8),
+                          Wrap(
+                            spacing: 12,
+                            runSpacing: 12,
+                            children: [
+                              FilledButton.icon(
+                                onPressed: checkInLoading
+                                    ? null
+                                    : () async {
+                                        setSheetState(() => checkInLoading = true);
+                                        final location = await _resolveCurrentLocationName();
+                                        if (!mounted) return;
+                                        setSheetState(() {
+                                          checkInLoading = false;
+                                          if (location != null) {
+                                            selectedCheckIn = location;
+                                          } else {
+                                            _toast(context, I18n.t(context, 'location_fetch_failed'));
+                                          }
+                                        });
+                                      },
+                                icon: checkInLoading
+                                    ? const SizedBox(
+                                        width: 16,
+                                        height: 16,
+                                        child: CircularProgressIndicator(strokeWidth: 2),
+                                      )
+                                    : const Icon(Icons.my_location),
+                                label: Text(I18n.t(context, 'use_current_location')),
+                              ),
+                              OutlinedButton.icon(
+                                onPressed: () async {
+                                  final value = await _promptManualLocation(ctx2, selectedCheckIn);
+                                  if (value != null) {
+                                    setSheetState(() => selectedCheckIn = value);
+                                  }
+                                },
+                                icon: const Icon(Icons.edit_location_alt),
+                                label: Text(I18n.t(context, 'set_location')),
+                              ),
+                            ],
+                          ),
+                          if (selectedCheckIn != null && selectedCheckIn!.isNotEmpty)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 8),
+                              child: InputChip(
+                                avatar: const Icon(Icons.place_outlined),
+                                label: Text(selectedCheckIn!),
+                                onDeleted: () => setSheetState(() => selectedCheckIn = null),
+                              ),
+                            ),
+                         
+                          if (hasNewAttachment || showExistingAttachment) ...[
+                            const SizedBox(height: 16),
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(16),
+                              child: Stack(
+                                children: [
+                                  if (pickedMedia != null)
+                                    FutureBuilder<Uint8List>(
+                                      future: pickedMedia!.readAsBytes(),
+                                      builder: (context, snap) {
+                                        if (!snap.hasData) {
+                                          return const SizedBox(
+                                            height: 160,
+                                            child: Center(child: CircularProgressIndicator()),
+                                          );
+                                        }
+                                        return Image.memory(snap.data!, height: 200, fit: BoxFit.cover);
+                                      },
+                                    )
+                                  else if (pickedGifUrl != null)
+                                    Image.network(
+                                      pickedGifUrl!,
+                                      height: 200,
+                                      width: double.infinity,
+                                      fit: BoxFit.cover,
+                                      loadingBuilder: (context, child, progress) {
+                                        if (progress == null) return child;
+                                        return SizedBox(
+                                          height: 200,
+                                          child: Center(
+                                            child: CircularProgressIndicator(
+                                              value: progress.expectedTotalBytes != null
+                                                  ? progress.cumulativeBytesLoaded /
+                                                      progress.expectedTotalBytes!
+                                                  : null,
+                                            ),
+                                          ),
+                                        );
+                                      },
+                                      errorBuilder: (_, __, ___) => Container(
+                                        height: 200,
+                                        color: Colors.black26,
+                                        alignment: Alignment.center,
+                                        child: const Icon(Icons.broken_image, size: 32),
+                                      ),
+                                    )
+                                  else if (showExistingAttachment)
+                                    Image.network(
+                                      _normalizeUploadUrl(existingImageUrl!),
+                                      height: 200,
+                                      width: double.infinity,
+                                      fit: BoxFit.cover,
+                                    ),
+                                  if (hasNewAttachment)
+                                    Positioned(
+                                      top: 8,
+                                      right: 8,
+                                      child: Material(
+                                        color: Colors.black54,
+                                        shape: const CircleBorder(),
+                                        child: IconButton(
+                                          icon: const Icon(Icons.close, color: Colors.white, size: 18),
+                                          onPressed: () => setSheetState(() {
+                                            pickedMedia = null;
+                                            pickedGifUrl = null;
+                                          }),
+                                        ),
+                                      ),
+                                    ),
+                                ],
+                              ),
+                            ),
+                          ],
+                          const SizedBox(height: 18),
+                          Wrap(
+                            spacing: 12,
+                            runSpacing: 12,
+                            children: [
+                              FilledButton.icon(
+                                onPressed: () async {
+                                  final file = await ImagePicker().pickImage(
+                                    source: ImageSource.gallery,
+                                    imageQuality: 85,
+                                  );
+                                  if (file != null) {
+                                    setSheetState(() {
+                                      pickedMedia = file;
+                                      pickedGifUrl = null;
+                                    });
+                                  }
+                                },
+                                icon: const Icon(Icons.image),
+                                label: Text(I18n.t(context, 'add_image')),
+                              ),
+                              FilledButton.icon(
+                                onPressed: () async {
+                                  final source = await _chooseGifSource(ctx2);
+                                  if (source == 'device') {
+                                    final file = await ImagePicker().pickImage(
+                                      source: ImageSource.gallery,
+                                      imageQuality: 100,
+                                    );
+                                    if (file != null) {
+                                      if (!_isGifFile(file)) {
+                                        _toast(context, I18n.t(context, 'invalid_gif'));
+                                      } else {
+                                        setSheetState(() {
+                                          pickedMedia = file;
+                                          pickedGifUrl = null;
+                                        });
+                                      }
+                                    }
+                                  } else if (source == 'url') {
+                                    final url = await _promptGifUrl(ctx2, initialValue: pickedGifUrl);
+                                    if (url != null) {
+                                      setSheetState(() {
+                                        pickedGifUrl = url;
+                                        pickedMedia = null;
+                                      });
+                                    }
+                                  }
+                                },
+                                icon: const Icon(Icons.gif_box),
+                                label: Text(I18n.t(context, 'attach_gif')),
+                              ),
+                              OutlinedButton.icon(
+                                onPressed: selectedGradient != null
+                                    ? () => setSheetState(() => selectedGradient = null)
+                                    : null,
+                                icon: const Icon(Icons.layers_clear),
+                                label: const Text('Reset vibe'),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 12),
+                          Align(
+                            alignment: Alignment.centerRight,
+                            child: FilledButton(
+                              onPressed: canPublish ? () => Navigator.pop(ctx, true) : null,
+                              child: Text(isEdit ? I18n.t(context, 'save') : I18n.t(context, 'publish')),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            );
+          }),
+        );
+      },
+    );
+
+    if (result != true) {
+      controller.dispose();
+      return;
+    }
+
+    try {
+      var content = controller.text.trim();
+      if (content.isEmpty) return;
+      final meta = <String>[];
+      if (selectedFeeling != null && selectedFeeling!.isNotEmpty) {
+        meta.add('Mood: $selectedFeeling');
+      }
+      if (selectedActivity != null && selectedActivity!.isNotEmpty) {
+        meta.add('Activity: $selectedActivity');
+      }
+      if (selectedCheckIn != null && selectedCheckIn!.isNotEmpty) {
+        meta.add('Check-in: $selectedCheckIn');
+      }
+      if (selectedGradient != null) {
+        meta.add('Vibe: Palette #${selectedGradient! + 1}');
+      }
+      if (meta.isNotEmpty) {
+        content = [
+          content,
+          meta.map((m) => '• $m').join('\n'),
+        ].where((section) => section.trim().isNotEmpty).join('\n\n');
+      }
+
+      if (isEdit) {
+        final postId = (existing?['id'] as num?)?.toInt();
+        if (postId == null) return;
+        if (pickedMedia != null || pickedGifUrl != null) {
+          _toast(context, I18n.t(context, 'edit_attachment_not_supported'));
+        }
+        await ApiService().updatePost(token, postId, content: content);
+        await _fetchPosts();
+        _toast(context, I18n.t(context, 'post_updated'));
+        HapticFeedback.selectionClick();
+      } else {
+        if (pickedGifUrl != null) {
+          try {
+            final uri = Uri.parse(pickedGifUrl!);
+            final response = await http.get(uri);
+            if (response.statusCode >= 200 && response.statusCode < 300) {
+              await ApiService().createPostWithImageBytes(
+                token,
+                content,
+                response.bodyBytes,
+                filename: 'gif_${DateTime.now().millisecondsSinceEpoch}.gif',
+                contentType: 'image/gif',
+              );
+            } else {
+              throw Exception('GIF status ${response.statusCode}');
+            }
+          } catch (e) {
+            _toast(context, I18n.t(context, 'gif_fetch_failed'));
+            return;
+          }
+        } else if (pickedMedia != null) {
+          final isGif = _isGifFile(pickedMedia!);
+          if (kIsWeb) {
+            final bytes = await pickedMedia!.readAsBytes();
+            await ApiService().createPostWithImageBytes(
+              token,
+              content,
+              bytes,
+              filename: pickedMedia!.name.isNotEmpty ? pickedMedia!.name : 'upload.jpg',
+              contentType: isGif ? 'image/gif' : null,
+            );
+          } else {
+            await ApiService().createPostWithImage(
+              token,
+              content,
+              pickedMedia!.path,
+              filename: pickedMedia!.name,
+              contentType: isGif ? 'image/gif' : null,
+            );
+          }
+        } else {
+          await ApiService().createPost(token, content);
+        }
+        await _fetchPosts();
+        _toast(context, I18n.t(context, 'post_published'));
+        HapticFeedback.mediumImpact();
+      }
+    } catch (e) {
+      _toast(context, '${I18n.t(context, 'save_failed')}: $e');
+    } finally {
+      controller.dispose();
+    }
+  }
+
+  String _normalizeUploadUrl(String? url) {
+    if (url == null || url.isEmpty) return '';
+    if (url.startsWith('http')) return url;
+    return ApiService.uploadBaseUrl + url;
+  }
+
+  _PostContentParts _parsePostContent(String? raw) {
+    if (raw == null || raw.trim().isEmpty) {
+      return const _PostContentParts(text: '');
+    }
+    final lines = raw.split('\\n');
+    final bodyLines = <String>[];
+    String? mood;
+    String? activity;
+    String? checkIn;
+    String? vibe;
+    final metaPattern = RegExp(r'^•\\s*(.+?):\\s*(.+)\$', caseSensitive: false);
+    for (final line in lines) {
+      final trimmed = line.trim();
+      final match = metaPattern.firstMatch(trimmed);
+      if (match != null) {
+        final key = match.group(1)!.toLowerCase();
+        final value = match.group(2)!.trim();
+        if (key.startsWith('mood')) {
+          mood = value;
+        } else if (key.startsWith('activity')) {
+          activity = value;
+        } else if (key.startsWith('check')) {
+          checkIn = value;
+        } else if (key.startsWith('vibe')) {
+          vibe = value;
+        }
+        continue;
+      }
+      if (trimmed.startsWith('• Vibe palette')) {
+        vibe = trimmed.replaceFirst('•', '').trim();
+        continue;
+      }
+      bodyLines.add(line);
+    }
+    final textOnly = bodyLines.join('\\n').trim();
+    return _PostContentParts(
+      text: textOnly,
+      mood: mood,
+      activity: activity,
+      checkIn: checkIn,
+      vibe: vibe,
+    );
+  }
+
+  int? _vibeIndexFromMeta(String? vibe, int paletteCount) {
+    if (vibe == null || vibe.isEmpty) return null;
+    final match = RegExp(r'#(\\d+)').firstMatch(vibe);
+    if (match == null) return null;
+    final parsed = int.tryParse(match.group(1) ?? '');
+    if (parsed == null) return null;
+    final index = parsed - 1;
+    if (index < 0 || index >= paletteCount) return null;
+    return index;
+  }
+
+  Future<String?> _resolveCurrentLocationName() async {
+    try {
+      final response = await http.get(Uri.parse('https://ipapi.co/json/'));
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        final city = data['city']?.toString();
+        final country = data['country_name']?.toString();
+        if ((city == null || city.isEmpty) && (country == null || country.isEmpty)) {
+          return null;
+        }
+        if (city == null || city.isEmpty) return country;
+        if (country == null || country.isEmpty) return city;
+        return '$city, $country';
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  Future<String?> _promptManualLocation(BuildContext context, String? initial) async {
+    final controller = TextEditingController(text: initial ?? '');
+    final result = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(I18n.t(context, 'set_location')),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: InputDecoration(hintText: I18n.t(context, 'location_hint')),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx), child: Text(I18n.t(context, 'cancel'))),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, controller.text.trim()),
+            child: Text(I18n.t(context, 'save')),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (result == null) return null;
+    final trimmed = result.trim();
+    return trimmed.isEmpty ? null : trimmed;
+  }
+
+  Future<String?> _chooseGifSource(BuildContext context) {
+    return showModalBottomSheet<String>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: Text(I18n.t(context, 'gif_from_device')),
+              onTap: () => Navigator.pop(ctx, 'device'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.link),
+              title: Text(I18n.t(context, 'gif_from_url')),
+              onTap: () => Navigator.pop(ctx, 'url'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<String?> _promptGifUrl(BuildContext context, {String? initialValue}) async {
+    final controller = TextEditingController(text: initialValue ?? '');
+    final result = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(I18n.t(context, 'attach_gif')),
+        content: TextField(
+          controller: controller,
+          keyboardType: TextInputType.url,
+          decoration: InputDecoration(hintText: I18n.t(context, 'gif_url_hint')),
+          autofocus: true,
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx), child: Text(I18n.t(context, 'cancel'))),
+          FilledButton(onPressed: () => Navigator.pop(ctx, controller.text.trim()), child: Text(I18n.t(context, 'save'))),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (result == null) return null;
+    final trimmed = result.trim();
+    if (trimmed.isEmpty) return null;
+    final uri = Uri.tryParse(trimmed);
+    if (uri == null || (!uri.hasScheme || !(uri.isScheme('http') || uri.isScheme('https')))) {
+      _toast(context, I18n.t(context, 'invalid_gif_url'));
+      return null;
+    }
+    return trimmed;
+  }
+
+  bool _isGifFile(XFile file) {
+    final reference = (file.name.isNotEmpty ? file.name : file.path).toLowerCase();
+    return reference.endsWith('.gif');
+  }
+
+  ImageProvider? _stickerProviderFor(dynamic raw) {
+    if (raw == null) return null;
+    final value = raw.toString();
+    if (value.isEmpty) return null;
+    if (value.startsWith('http')) {
+      return NetworkImage(_normalizeUploadUrl(value));
+    }
+    if (value.startsWith('assets/')) {
+      return AssetImage(value);
+    }
+    return AssetImage('assets/stickers/$value');
+  }
+
+  Widget _postCard(BuildContext context, Map<String, dynamic> post) {
+    final theme = Theme.of(context);
+    final postId = (post['id'] as num?)?.toInt() ?? 0;
+    final storedCounts = _reactionCounts[postId];
+    final counts = storedCounts != null
+        ? Map<String, int>.from(storedCounts)
+        : _countsFromDynamic(post['reactions']);
+    counts.putIfAbsent('like', () => post['likes'] is num ? (post['likes'] as num).toInt() : 0);
+    final totalReactions = _totalReactions(counts);
+    final userReaction = _userReactions[postId];
+    final commentCount = _commentCounts[postId] ?? (post['comments_count'] as int? ?? 0);
+
+    final parts = _parsePostContent(post['content'] as String?);
+    final bodyText = parts.text;
+    final vibeIndex = _vibeIndexFromMeta(parts.vibe, _kVibePalettes.length);
+    final vibePalette = vibeIndex != null ? _kVibePalettes[vibeIndex] : null;
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(28),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+        child: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [
+                theme.colorScheme.surface.withOpacity(0.92),
+                theme.colorScheme.surfaceVariant.withOpacity(0.7),
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            borderRadius: BorderRadius.circular(28),
+            border: Border.all(color: Colors.white.withOpacity(0.08)),
+            boxShadow: [
+              BoxShadow(color: Colors.black.withOpacity(0.12), blurRadius: 26, offset: const Offset(0, 14)),
+            ],
+          ),
+          padding: const EdgeInsets.fromLTRB(18, 18, 18, 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _postHeader(context, post, parts),
+              if (bodyText.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                _PostBodyBlock(text: bodyText, palette: vibePalette),
+              ],
+              if ((post['image_url'] as String?)?.isNotEmpty == true) ...[
+                const SizedBox(height: 14),
+                _postMedia(context, post['image_url'] as String),
+              ],
+              if (totalReactions > 0) ...[
+                const SizedBox(height: 16),
+                _ReactionSummary(
+                  counts: counts,
+                  total: totalReactions,
+                  onTap: () => _openReactionDetails(context, postId),
+                ),
+              ],
+              const SizedBox(height: 16),
+              _postFooter(
+                context,
+                postId: postId,
+                userReaction: userReaction,
+                totalReactions: totalReactions,
+                commentCount: commentCount,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _postHeader(BuildContext context, Map<String, dynamic> post, _PostContentParts parts) {
+    final theme = Theme.of(context);
+    final user = post['user'] as Map<String, dynamic>?;
+    final displayName = [
+      user?['full_name'],
+      user?['name'],
+      user?['username'],
+    ].map((value) => value?.toString().trim()).firstWhere((value) => value != null && value!.isNotEmpty, orElse: () => 'User')!;
+    final avatar = (user?['avatar'] as String?) ?? '';
+    final frame = (user?['frame'] as String?) ?? 'none';
+    final sticker = _stickerProviderFor(user?['sticker'] ?? user?['avatar_sticker']);
+    final createdAt = post['created_at'] as String?;
+    final visibility = post['visibility'] as String? ?? 'public';
+    final chips = <Widget>[];
+    final timeAgo = _timeAgo(createdAt);
+    if (timeAgo.isNotEmpty) {
+      chips.add(
+        _PostMetaInfoChip(
+          icon: Icons.access_time,
+          label: timeAgo,
+          trailing: Icon(_visibilityIcon(visibility), size: 14, color: theme.hintColor),
+        ),
+      );
+    }
+    if (parts.mood != null && parts.mood!.isNotEmpty) {
+      chips.add(_PostMetaPill(icon: Icons.emoji_emotions_outlined, label: parts.mood!, color: theme.colorScheme.primary));
+    }
+    if (parts.activity != null && parts.activity!.isNotEmpty) {
+      chips.add(_PostMetaPill(icon: Icons.flash_on, label: parts.activity!, color: theme.colorScheme.secondary));
+    }
+    if (parts.checkIn != null && parts.checkIn!.isNotEmpty) {
+      chips.add(_PostMetaPill(icon: Icons.place_outlined, label: parts.checkIn!, color: theme.colorScheme.tertiary));
+    }
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        FramedAvatar(
+          image: avatar.isNotEmpty ? NetworkImage(_normalizeUploadUrl(avatar)) : null,
+          name: displayName,
+          radius: 20,
+          frameStyle: frame,
+          stickerImage: sticker,
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(displayName, style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600)),
+              const SizedBox(height: 6),
+              Wrap(
+                spacing: 8,
+                runSpacing: 6,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: chips,
+              ),
+            ],
+          ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.more_horiz),
+          onPressed: () => _showPostActions(context, post),
+        )
+      ],
+    );
+  }
+
+  Widget _postMedia(BuildContext context, String url) {
+    final normalized = _normalizeUploadUrl(url);
+    return GestureDetector(
+      onTap: () => _openImageViewer(context, normalized),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(16),
+        child: Image.network(
+          normalized,
+          fit: BoxFit.cover,
+          loadingBuilder: (context, child, progress) {
+            if (progress == null) return child;
+            return SizedBox(
+              height: 200,
+              child: Center(
+                child: CircularProgressIndicator(value: progress.expectedTotalBytes != null
+                    ? progress.cumulativeBytesLoaded / progress.expectedTotalBytes!
+                    : null),
+              ),
+            );
+          },
+          errorBuilder: (_, __, ___) => Container(
+            height: 200,
+            color: Colors.black12,
+            alignment: Alignment.center,
+            child: const Icon(Icons.broken_image, size: 32),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _postFooter(
+    BuildContext context, {
+    required int postId,
+    required String? userReaction,
+    required int totalReactions,
+    required int commentCount,
+  }) {
+    final theme = Theme.of(context);
+    final visual = _visualForReaction(userReaction ?? 'like');
+    final isActive = userReaction != null;
+    return Row(
+      children: [
+        _ReactionPill(
+          leading: Icon(visual.icon, size: 18, color: isActive ? visual.color : theme.hintColor),
+          label: isActive ? _reactionLabel(context, userReaction!) : I18n.t(context, 'like'),
+          count: totalReactions,
+          color: isActive ? visual.color : null,
+          active: isActive,
+          onTap: () => _toggleReaction(context, postId, userReaction ?? 'like'),
+          onLongPress: () => _openReactionPicker(context, postId),
+          onCountTap: totalReactions > 0 ? () => _openReactionDetails(context, postId) : null,
+        ),
+        const SizedBox(width: 12),
+        _ReactionPill(
+          leading: Icon(Icons.mode_comment_outlined, size: 18, color: theme.hintColor),
+          label: I18n.t(context, 'comment'),
+          count: commentCount,
+          color: null,
+          onTap: () => _openComments(context, postId),
+        ),
+        const Spacer(),
+        _GlassIconButton(
+          icon: Icons.ios_share,
+          label: I18n.t(context, 'share'),
+          onTap: () => _toast(context, I18n.t(context, 'coming_soon')),
+        ),
+      ],
+    );
+  }
+
+  bool _isPostOwner(Map<String, dynamic> post) {
+    if (post['is_owner'] == true) return true;
+    final user = post['user'] as Map<String, dynamic>?;
+    final postOwner = _asInt(user?['id']) ?? _asInt(post['user_id']);
+    return _currentUserId != null && postOwner == _currentUserId;
+  }
+
+  Future<void> _showPostActions(BuildContext context, Map<String, dynamic> post) async {
+    final isOwner = _isPostOwner(post);
+    final result = await showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) {
+        final theme = Theme.of(ctx);
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(22),
+            child: BackdropFilter(
+              filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+              child: Container(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      theme.colorScheme.surface.withOpacity(0.96),
+                      theme.colorScheme.surfaceVariant.withOpacity(0.82),
+                    ],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                  border: Border.all(color: Colors.white.withOpacity(0.12)),
+                ),
+                child: SafeArea(
+                  top: false,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (isOwner)
+                        ListTile(
+                          leading: const Icon(Icons.edit),
+                          title: Text(I18n.t(context, 'edit_post')),
+                          onTap: () => Navigator.pop(ctx, 'edit'),
+                        ),
+                      if (isOwner)
+                        ListTile(
+                          leading: const Icon(Icons.delete_forever),
+                          title: Text(I18n.t(context, 'delete')),
+                          onTap: () => Navigator.pop(ctx, 'delete'),
+                        ),
+                      ListTile(
+                        leading: const Icon(Icons.copy),
+                        title: Text(I18n.t(context, 'share')),
+                        onTap: () => Navigator.pop(ctx, 'copy'),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+
+    switch (result) {
+      case 'edit':
+        _openCreatePost(context, existing: post);
+        break;
+      case 'delete':
+        await _deletePost(context, post);
+        break;
+      case 'copy':
+        final content = (post['content'] as String?) ?? '';
+        await Clipboard.setData(ClipboardData(text: content));
+        _toast(context, I18n.t(context, 'copied'));
+        break;
+    }
+  }
+
+  Future<void> _deletePost(BuildContext context, Map<String, dynamic> post) async {
+    final sp = await SharedPreferences.getInstance();
+    final token = sp.getString('auth_token');
+    if (token == null) {
+      _toast(context, I18n.t(context, 'not_authenticated'));
+      return;
+    }
+    final id = _asInt(post['id']);
+    if (id == null) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(I18n.t(context, 'delete')),
+        content: Text(I18n.t(context, 'delete_post_confirm')),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: Text(I18n.t(context, 'cancel'))),
+          FilledButton(onPressed: () => Navigator.pop(ctx, true), child: Text(I18n.t(context, 'delete'))),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    try {
+      await ApiService().deletePost(token, id);
+      if (!mounted) return;
+      setState(() {
+        _posts.removeWhere((element) => _asInt(element['id']) == id);
+        _reactionCounts.remove(id);
+        _userReactions.remove(id);
+        _commentCounts.remove(id);
+      });
+      _toast(context, I18n.t(context, 'post_deleted'));
+    } catch (e) {
+      _toast(context, '${I18n.t(context, 'save_failed')}: $e');
+    }
+  }
+
+  Future<void> _openComments(BuildContext context, int postId) async {
+    final sp = await SharedPreferences.getInstance();
+    final token = sp.getString('auth_token');
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) {
+        final bottom = MediaQuery.of(ctx).viewInsets.bottom;
+        return Padding(
+          padding: EdgeInsets.only(bottom: bottom),
+          child: _CommentsSheet(
+            postId: postId,
+            token: token,
+            onCountChanged: (count) {
+              if (!mounted) return;
+              setState(() => _commentCounts[postId] = count);
+            },
+            normalizeUrl: _normalizeUploadUrl,
+            timeAgo: _timeAgo,
+            currentUserId: _currentUserId,
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _toggleReaction(BuildContext context, int postId, String reactionType) async {
+    final sp = await SharedPreferences.getInstance();
+    final token = sp.getString('auth_token');
+    if (token == null) {
+      _toast(context, I18n.t(context, 'not_authenticated'));
+      return;
+    }
+    try {
+      await ApiService().reactToPost(token, postId, type: reactionType);
+      await _refreshReactionsFor(postId);
+    } catch (e) {
+      _toast(context, 'Eroare: $e');
+    }
+  }
+
+  Future<void> _openReactionDetails(BuildContext context, int postId) async {
+    try {
+      final sp = await SharedPreferences.getInstance();
+      final token = sp.getString('auth_token');
+      final data = await ApiService().getReactions(postId, token: token);
+      if (!mounted) return;
+      final rawList = data['reactions'];
+      final reactions = <Map<String, dynamic>>[];
+      if (rawList is List) {
+        for (final item in rawList) {
+          if (item is Map) {
+            reactions.add(item.map((key, value) => MapEntry(key.toString(), value)));
+          }
+        }
+      }
+      if (!context.mounted) return;
+      await showModalBottomSheet(
+        context: context,
+        backgroundColor: Colors.transparent,
+        builder: (ctx) => _ReactionDetailsSheet(
+          reactions: reactions,
+          normalizeUrl: _normalizeUploadUrl,
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      _toast(context, '${I18n.t(context, 'error')}: $e');
+    }
+  }
+
+  Future<void> _openReactionPicker(BuildContext context, int postId) async {
+    final selected = await showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) {
+        final theme = Theme.of(ctx);
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(26),
+            child: BackdropFilter(
+              filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      theme.colorScheme.surface.withOpacity(0.95),
+                      theme.colorScheme.surfaceVariant.withOpacity(0.78),
+                    ],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                  border: Border.all(color: Colors.white.withOpacity(0.12)),
+                ),
+                child: SafeArea(
+                  top: false,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        I18n.t(ctx, 'choose_reaction'),
+                        style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                      ),
+                      const SizedBox(height: 16),
+                      Wrap(
+                        spacing: 12,
+                        runSpacing: 12,
+                        children: [
+                          for (final type in _kReactionOrder)
+                            _ReactionChoice(
+                              visual: _visualForReaction(type),
+                              label: _reactionLabel(ctx, type),
+                              onTap: () => Navigator.of(ctx).pop(type),
+                            ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+    if (selected != null) {
+      await _toggleReaction(context, postId, selected);
+    }
+  }
+
+  Future<void> _ensureCommentsCount(int postId) async {
+    if (_commentCounts.containsKey(postId)) return;
+    try {
+      final list = await ApiService().getComments(postId);
+      if (!mounted) return;
+      setState(() => _commentCounts[postId] = list.length);
+    } catch (_) {}
+  }
+
+  Future<void> _refreshReactionsFor(int postId) async {
+    try {
+      final data = await ApiService().getReactions(postId);
+      final parsed = _countsFromDynamic(data['counts']);
+      if (!mounted) return;
+      setState(() {
+        _reactionCounts[postId] = parsed;
+        _userReactions[postId] = data['user_reaction'] as String?;
+      });
+    } catch (_) {}
+  }
+
+  IconData _visibilityIcon(String value) {
+    switch (value) {
+      case 'friends':
+        return Icons.group;
+      case 'private':
+        return Icons.lock;
+      default:
+        return Icons.public;
+    }
+  }
+
+  String _timeAgo(String? iso) {
+    if (iso == null || iso.isEmpty) return '';
+    try {
+      final dt = DateTime.tryParse(iso)?.toLocal();
+      if (dt == null) return '';
+      final diff = DateTime.now().difference(dt);
+      if (diff.inMinutes < 1) return 'acum câteva sec.';
+      if (diff.inMinutes < 60) return 'acum ${diff.inMinutes} min';
+      if (diff.inHours < 24) return 'acum ${diff.inHours} h';
+      if (diff.inDays < 7) return 'acum ${diff.inDays} z';
+      return '${dt.year}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}';
+    } catch (_) {
+      return '';
+    }
+  }
+
+  Future<_ComposerAvatar> _loadAvatarForComposer({bool refresh = false}) async {
+    final sp = await SharedPreferences.getInstance();
+    String? name = sp.getString('profile_name');
+    String frame = sp.getString('profile_avatar_frame') ?? 'none';
+    String? avatarUrl = sp.getString('profile_avatar_url');
+    final token = sp.getString('auth_token');
+
+    final needsFetch = refresh ||
+        avatarUrl == null ||
+        avatarUrl.isEmpty ||
+        name == null ||
+        name.isEmpty;
+    if (needsFetch && token != null && token.isNotEmpty) {
+      try {
+        final profile = await ApiService().getProfile(token);
+        final remoteName = (profile['full_name'] as String?)?.trim();
+        final remoteFrame = (profile['avatar_frame'] as String?)?.trim();
+        final remoteAvatar = (profile['avatar_url'] as String?)?.trim();
+        if (remoteName != null && remoteName.isNotEmpty) {
+          name = remoteName;
+          await sp.setString('profile_name', remoteName);
+        }
+        if (remoteFrame != null && remoteFrame.isNotEmpty) {
+          frame = remoteFrame;
+          await sp.setString('profile_avatar_frame', remoteFrame);
+        }
+        if (remoteAvatar != null && remoteAvatar.isNotEmpty) {
+          avatarUrl = remoteAvatar;
+          await sp.setString('profile_avatar_url', remoteAvatar);
+        }
+      } catch (_) {}
+    }
+
+    name ??= sp.getString('auth_username') ?? 'U';
+    final initials = name.trim().isNotEmpty ? name.trim()[0].toUpperCase() : 'U';
+    ImageProvider? image;
+    if (avatarUrl != null && avatarUrl.isNotEmpty) {
+      image = NetworkImage(_normalizeUploadUrl(avatarUrl));
+    }
+    return _ComposerAvatar(image, initials, frame);
+  }
+
+  void _openImageViewer(BuildContext context, String url) {
+    showDialog(
+      context: context,
+      barrierColor: Colors.black.withOpacity(0.65),
+      builder: (_) => Dialog(
+        insetPadding: const EdgeInsets.all(16),
+        clipBehavior: Clip.antiAlias,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        child: InteractiveViewer(
+          minScale: 0.5,
+          maxScale: 5,
+          child: Image.network(url, fit: BoxFit.contain),
+        ),
+      ),
+    );
+  }
+  
+}
+
+class _ReactionPill extends StatelessWidget {
+  const _ReactionPill({
+    required this.leading,
+    required this.label,
+    required this.count,
+    required this.onTap,
+    this.onLongPress,
+    this.active = false,
+    this.color,
+    this.dense = false,
+    this.onCountTap,
+  });
+
+  final Widget leading;
+  final String label;
+  final int count;
+  final bool active;
+  final VoidCallback onTap;
+  final VoidCallback? onLongPress;
+  final Color? color;
+  final bool dense;
+  final VoidCallback? onCountTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final effectiveColor = color ?? (active ? theme.colorScheme.primary : theme.hintColor);
+    final horizontal = dense ? 12.0 : 14.0;
+    final vertical = dense ? 8.0 : 10.0;
+    final gradient = color != null
+        ? [
+            color!.withOpacity(active ? 0.25 : 0.16),
+            color!.withOpacity(active ? 0.12 : 0.06),
+          ]
+        : active
+            ? [
+                theme.colorScheme.primary.withOpacity(0.2),
+                theme.colorScheme.primary.withOpacity(0.08),
+              ]
+            : [
+                Colors.white.withOpacity(0.08),
+                Colors.white.withOpacity(0.03),
+              ];
+    final borderColor = color != null
+        ? color!.withOpacity(active ? 0.4 : 0.2)
+        : (active
+            ? theme.colorScheme.primary.withOpacity(0.4)
+            : Colors.white.withOpacity(0.12));
+    final countChip = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: effectiveColor.withOpacity(active || color != null ? 0.22 : 0.12),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text('$count', style: theme.textTheme.labelSmall?.copyWith(color: effectiveColor)),
+    );
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        gradient: LinearGradient(
+          colors: gradient,
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        border: Border.all(color: borderColor),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Material(
+        color: Colors.transparent,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            InkWell(
+              onTap: onTap,
+              onLongPress: onLongPress,
+              borderRadius: BorderRadius.circular(20),
+              child: Padding(
+                padding: EdgeInsets.symmetric(horizontal: horizontal, vertical: vertical),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    leading,
+                    const SizedBox(width: 6),
+                    Text(
+                      label,
+                      style: theme.textTheme.labelMedium?.copyWith(color: effectiveColor),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            if (count > 0) ...[
+              const SizedBox(width: 6),
+              InkWell(
+                onTap: onCountTap ?? onTap,
+                borderRadius: BorderRadius.circular(16),
+                child: Padding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: dense ? 4 : 6,
+                    vertical: dense ? 3 : 4,
+                  ),
+                  child: countChip,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GlassIconButton extends StatelessWidget {
+  const _GlassIconButton({required this.icon, required this.label, required this.onTap});
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(18),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+        child: Material(
+          color: Colors.white.withOpacity(0.08),
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(18),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 9),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(icon, size: 18, color: theme.hintColor),
+                  const SizedBox(width: 6),
+                  Text(label, style: theme.textTheme.labelMedium?.copyWith(color: theme.hintColor)),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ReactionSummary extends StatelessWidget {
+  const _ReactionSummary({required this.counts, required this.total, this.onTap});
+
+  final Map<String, int> counts;
+  final int total;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final top = _topReactions(counts);
+    if (top.isEmpty || total == 0) return const SizedBox.shrink();
+    final items = top.take(3).toList();
+    final theme = Theme.of(context);
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(20),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            color: Colors.white.withOpacity(0.06),
+            border: Border.all(color: Colors.white.withOpacity(0.1)),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(
+                height: 32,
+                width: 32 + (items.length - 1) * 18,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    for (var i = 0; i < items.length; i++)
+                      Positioned(
+                        left: i * 18,
+                        child: _ReactionBadge(visual: _visualForReaction(items[i].key)),
+                      ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              Text(
+                '${I18n.t(context, 'reactions')}: $total',
+                style: theme.textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w600),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ReactionBadge extends StatelessWidget {
+  const _ReactionBadge({required this.visual});
+
+  final _ReactionVisual visual;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 32,
+      height: 32,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: visual.color.withOpacity(0.15),
+        border: Border.all(color: visual.color.withOpacity(0.4), width: 1.5),
+      ),
+      child: Icon(visual.icon, size: 18, color: visual.color),
+    );
+  }
+}
+
+class _ReactionDetailsSheet extends StatelessWidget {
+  const _ReactionDetailsSheet({required this.reactions, required this.normalizeUrl});
+
+  final List<Map<String, dynamic>> reactions;
+  final String Function(String?) normalizeUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final maxHeight = MediaQuery.of(context).size.height * 0.65;
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(26),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+          child: Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [
+                  theme.colorScheme.surface.withOpacity(0.96),
+                  theme.colorScheme.surfaceVariant.withOpacity(0.82),
+                ],
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+              ),
+              border: Border.all(color: Colors.white.withOpacity(0.12)),
+            ),
+            child: SafeArea(
+              top: false,
+              child: ConstrainedBox(
+                constraints: BoxConstraints(maxHeight: maxHeight),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 20, 20, 8),
+                      child: Row(
+                        children: [
+                          Icon(Icons.emoji_emotions, color: theme.colorScheme.primary),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Text(
+                              I18n.t(context, 'people_reacted'),
+                              style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                            ),
+                          ),
+                          IconButton(
+                            onPressed: () => Navigator.pop(context),
+                            icon: const Icon(Icons.close),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const Divider(height: 1, thickness: 1, indent: 16, endIndent: 16),
+                    if (reactions.isEmpty)
+                      Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Text(
+                          I18n.t(context, 'no_reactions_yet'),
+                          style: theme.textTheme.bodyMedium,
+                          textAlign: TextAlign.center,
+                        ),
+                      )
+                    else
+                      Expanded(
+                        child: ListView.separated(
+                          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                          itemBuilder: (ctx, index) {
+                            final entry = reactions[index];
+                            final type = entry['type']?.toString() ?? 'like';
+                            final visual = _visualForReaction(type);
+                            final rawName = entry['name']?.toString().trim();
+                            final name = (rawName == null || rawName.isEmpty) ? 'User' : rawName;
+                            final username = entry['username']?.toString().trim();
+                            final avatarUrl = entry['avatar_url']?.toString().trim();
+                            ImageProvider? avatar;
+                            if (avatarUrl != null && avatarUrl.isNotEmpty) {
+                              avatar = NetworkImage(normalizeUrl(avatarUrl));
+                            }
+                            final subtitle = (username != null && username.isNotEmpty) ? '@$username' : null;
+                            final initials = name.isNotEmpty ? name[0].toUpperCase() : '?';
+                            return ListTile(
+                              leading: CircleAvatar(
+                                backgroundImage: avatar,
+                                backgroundColor: theme.colorScheme.primary.withOpacity(0.1),
+                                child: avatar == null
+                                    ? Text(initials)
+                                    : null,
+                              ),
+                              title: Text(name, style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.w600)),
+                              subtitle: subtitle != null ? Text(subtitle, style: theme.textTheme.bodySmall) : null,
+                              trailing: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                crossAxisAlignment: CrossAxisAlignment.end,
+                                children: [
+                                  Icon(visual.icon, color: visual.color, size: 20),
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    I18n.t(ctx, visual.labelKey),
+                                    style: theme.textTheme.labelSmall?.copyWith(color: visual.color),
+                                  ),
+                                ],
+                              ),
+                            );
+                          },
+                          separatorBuilder: (_, __) => const Divider(height: 1, indent: 72),
+                          itemCount: reactions.length,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CommentAttachmentGallery extends StatelessWidget {
+  const _CommentAttachmentGallery({
+    required this.attachments,
+    required this.normalizeUrl,
+    required this.onPreview,
+  });
+
+  final List<_CommentAttachment> attachments;
+  final String Function(String?) normalizeUrl;
+  final void Function(String url) onPreview;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      children: attachments.map((attachment) {
+        final url = normalizeUrl(attachment.url);
+        final overlayColor = attachment.type == _CommentAttachmentType.gif
+            ? theme.colorScheme.primary
+            : theme.colorScheme.secondary;
+        return GestureDetector(
+          onTap: () => onPreview(url),
+          child: SizedBox(
+            width: 120,
+            child: AspectRatio(
+              aspectRatio: 4 / 3,
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(16),
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    Container(color: Colors.black12),
+                    Image.network(
+                      url,
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, __, ___) => const Icon(Icons.broken_image),
+                    ),
+                    if (attachment.type == _CommentAttachmentType.gif)
+                      Align(
+                        alignment: Alignment.bottomRight,
+                        child: Container(
+                          margin: const EdgeInsets.all(6),
+                          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: overlayColor.withOpacity(0.75),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: const Text('GIF', style: TextStyle(color: Colors.white, fontWeight: FontWeight.w700)),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}
+
+class _ComposerAttachmentPreview extends StatelessWidget {
+  const _ComposerAttachmentPreview({
+    required this.attachments,
+    required this.normalizeUrl,
+    required this.onRemove,
+    required this.onPreview,
+  });
+
+  final List<_CommentAttachment> attachments;
+  final String Function(String?) normalizeUrl;
+  final void Function(int index) onRemove;
+  final void Function(String url) onPreview;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      children: attachments.asMap().entries.map((entry) {
+        final index = entry.key;
+        final attachment = entry.value;
+        final url = normalizeUrl(attachment.url);
+        return GestureDetector(
+          onTap: () => onPreview(url),
+          child: SizedBox(
+            width: 110,
+            child: AspectRatio(
+              aspectRatio: 4 / 3,
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(16),
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    Container(color: Colors.black12),
+                    Image.network(
+                      url,
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, __, ___) => const Icon(Icons.broken_image),
+                    ),
+                    Positioned(
+                      top: 6,
+                      right: 6,
+                      child: Material(
+                        color: Colors.black54,
+                        shape: const CircleBorder(),
+                        child: InkWell(
+                          onTap: () => onRemove(index),
+                          customBorder: const CircleBorder(),
+                          child: const Padding(
+                            padding: EdgeInsets.all(4),
+                            child: Icon(Icons.close, size: 16, color: Colors.white),
+                          ),
+                        ),
+                      ),
+                    ),
+                    if (attachment.type == _CommentAttachmentType.gif)
+                      Align(
+                        alignment: Alignment.bottomRight,
+                        child: Container(
+                          margin: const EdgeInsets.all(6),
+                          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.primary.withOpacity(0.8),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: const Text('GIF', style: TextStyle(color: Colors.white, fontWeight: FontWeight.w700)),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}
+
+class _ReactionChoice extends StatelessWidget {
+  const _ReactionChoice({required this.visual, required this.label, required this.onTap});
+
+  final _ReactionVisual visual;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(20),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            gradient: LinearGradient(
+              colors: [
+                visual.color.withOpacity(0.22),
+                visual.color.withOpacity(0.12),
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            border: Border.all(color: visual.color.withOpacity(0.42)),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(visual.icon, color: visual.color),
+              const SizedBox(width: 8),
+              Text(label, style: theme.textTheme.labelLarge?.copyWith(fontWeight: FontWeight.w600)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CommentsSheet extends StatefulWidget {
+  const _CommentsSheet({
+    required this.postId,
+    required this.token,
+    required this.onCountChanged,
+    required this.normalizeUrl,
+    required this.timeAgo,
+    required this.currentUserId,
+  });
+
+  final int postId;
+  final String? token;
+  final ValueChanged<int> onCountChanged;
+  final String Function(String?) normalizeUrl;
+  final String Function(String?) timeAgo;
+  final int? currentUserId;
+
+  @override
+  State<_CommentsSheet> createState() => _CommentsSheetState();
+}
+
+class _CommentsSheetState extends State<_CommentsSheet> {
+  final TextEditingController _controller = TextEditingController();
+  final FocusNode _focusNode = FocusNode();
+  final List<_CommentNode> _roots = [];
+  final Map<int, _CommentNode> _nodeById = {};
+  final Map<int, Map<String, int>> _commentReactions = {};
+  final Map<int, String?> _userCommentReactions = {};
+  final Set<int> _loadingReactions = <int>{};
+  final Set<int> _expandedComments = <int>{};
+  bool _loading = true;
+  bool _submitting = false;
+  String? _error;
+  _CommentNode? _replyTarget;
+  int? _editingCommentId;
+  final List<_CommentAttachment> _pendingAttachments = [];
+  bool _uploadingAttachment = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final list = await ApiService().getComments(widget.postId);
+      final normalized = <Map<String, dynamic>>[];
+      for (final item in list) {
+        normalized.add(_normalizeCommentRecord(item));
+      }
+      if (!mounted) return;
+      setState(() {
+        _roots
+          ..clear()
+          ..addAll(_buildCommentTree(normalized));
+        _nodeById
+          ..clear();
+        _indexNodes(_roots);
+        _expandedComments.clear();
+        _loading = false;
+      });
+      _prefetchCommentReactions();
+      widget.onCountChanged(_nodeById.length);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = '$e';
+        _loading = false;
+      });
+    }
+  }
+
+  List<_CommentNode> _buildCommentTree(List<Map<String, dynamic>> raw) {
+    final nodeMap = <int, _CommentNode>{};
+    final nodes = <_CommentNode>[];
+    for (final data in raw) {
+      final node = _CommentNode(data);
+      final id = node.id;
+      if (id != null) {
+        nodeMap[id] = node;
+      }
+      nodes.add(node);
+    }
+    final roots = <_CommentNode>[];
+    for (final node in nodes) {
+      final parentId = node.parentId;
+      if (parentId != null && nodeMap.containsKey(parentId)) {
+        nodeMap[parentId]!.children.add(node);
+      } else {
+        roots.add(node);
+      }
+    }
+    return roots;
+  }
+
+  void _indexNodes(List<_CommentNode> nodes) {
+    for (final node in nodes) {
+      final id = node.id;
+      if (id != null) {
+        _nodeById[id] = node;
+      }
+      if (node.children.isNotEmpty) {
+        _indexNodes(node.children);
+      }
+    }
+  }
+
+  void _insertComment(Map<String, dynamic> comment) {
+    final node = _CommentNode(_normalizeCommentRecord(comment));
+    final id = node.id;
+    if (id != null) {
+      _nodeById[id] = node;
+    }
+    final parentId = node.parentId;
+    if (parentId != null && _nodeById.containsKey(parentId)) {
+      final parent = _nodeById[parentId]!;
+      parent.children.insert(0, node);
+      _expandedComments.add(parentId);
+    } else {
+      _roots.insert(0, node);
+    }
+    if (id != null) {
+      unawaited(_fetchCommentReactions(id));
+    }
+  }
+
+  void _applyUpdatedComment(Map<String, dynamic> updated) {
+    final id = _asInt(updated['id']);
+    if (id == null) return;
+    final node = _nodeById[id];
+    if (node == null) return;
+    node.data = _normalizeCommentRecord(updated);
+  }
+
+  Map<String, dynamic> _normalizeCommentRecord(dynamic raw) {
+    final map = <String, dynamic>{};
+    if (raw is Map) {
+      raw.forEach((key, value) {
+        if (key == null) return;
+        map[key.toString()] = value;
+      });
+    }
+
+    Map<String, dynamic> ensureMap(dynamic value) {
+      if (value is Map<String, dynamic>) {
+        return Map<String, dynamic>.from(value);
+      }
+      if (value is Map) {
+        return value.map((k, v) => MapEntry(k.toString(), v));
+      }
+      return <String, dynamic>{};
+    }
+
+    String? clean(dynamic value) {
+      if (value == null) return null;
+      final text = value.toString().trim();
+      return text.isEmpty ? null : text;
+    }
+
+    final user = ensureMap(map['user']);
+    final id = _asInt(user['id']) ?? _asInt(map['user_id']);
+    if (id != null) {
+      user['id'] = id;
+    }
+
+    final resolvedName = clean(user['name']) ?? clean(user['full_name']) ?? clean(map['user_name']);
+    if (resolvedName != null) {
+      user.putIfAbsent('name', () => resolvedName);
+      user.putIfAbsent('full_name', () => resolvedName);
+      user.putIfAbsent('username', () => resolvedName);
+    } else if (id != null && clean(user['name']) == null) {
+      user['name'] = 'User #$id';
+      user.putIfAbsent('full_name', () => 'User #$id');
+      user.putIfAbsent('username', () => 'user$id');
+    }
+
+    final resolvedAvatar = clean(user['avatar']) ?? clean(map['user_avatar']);
+    if (resolvedAvatar != null) {
+      user['avatar'] = resolvedAvatar;
+    }
+
+    map['user'] = user;
+
+    final rawContent = map['content']?.toString() ?? '';
+    final parsedContent = _splitCommentContent(rawContent);
+    map['raw_content'] = rawContent;
+    map['content'] = parsedContent.text;
+    map['attachments'] = parsedContent.attachments.map((e) => e.toMap()).toList();
+    return map;
+  }
+
+  Future<void> _deleteComment(int id) async {
+    final token = widget.token;
+    if (token == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(I18n.t(context, 'not_authenticated'))),
+      );
+      return;
+    }
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(I18n.t(context, 'delete')),
+        content: Text(I18n.t(context, 'delete_comment_confirm')),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: Text(I18n.t(context, 'cancel'))),
+          FilledButton(onPressed: () => Navigator.pop(ctx, true), child: Text(I18n.t(context, 'delete'))),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    try {
+      await ApiService().deleteComment(token, id);
+      if (!mounted) return;
+      setState(() {
+        _removeNode(id);
+        if (_replyTarget?.id == id) _replyTarget = null;
+        if (_editingCommentId == id) {
+          _editingCommentId = null;
+          _controller.clear();
+        }
+      });
+      widget.onCountChanged(_nodeById.length);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(I18n.t(context, 'comment_deleted'))),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${I18n.t(context, 'save_failed')}: $e')),
+      );
+    }
+  }
+
+  void _removeNode(int id) {
+    _nodeById.remove(id);
+    _commentReactions.remove(id);
+    _userCommentReactions.remove(id);
+    _expandedComments.remove(id);
+    _removeNodeFromList(_roots, id);
+  }
+
+  bool _removeNodeFromList(List<_CommentNode> list, int id) {
+    for (var i = 0; i < list.length; i++) {
+      final node = list[i];
+      if (node.id == id) {
+        list.removeAt(i);
+        return true;
+      }
+      if (_removeNodeFromList(node.children, id)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  Future<void> _submit() async {
+    final token = widget.token;
+    if (token == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(I18n.t(context, 'not_authenticated'))),
+      );
+      return;
+    }
+    final text = _controller.text.trim();
+    if ((text.isEmpty && _pendingAttachments.isEmpty) || _submitting) return;
+    setState(() => _submitting = true);
+    try {
+      final sections = <String>[];
+      if (text.isNotEmpty) {
+        sections.add(text);
+      }
+      for (final attachment in _pendingAttachments) {
+        sections.add('$_kCommentAttachmentPrefix${attachment.type.name}|${attachment.url}');
+      }
+      final payload = sections.join('\n');
+      if (_editingCommentId != null) {
+        final updated = await ApiService().updateComment(token, _editingCommentId!, payload);
+        if (!mounted) return;
+        setState(() {
+          _applyUpdatedComment(updated);
+          _submitting = false;
+          _controller.clear();
+          _editingCommentId = null;
+          _pendingAttachments.clear();
+        });
+        HapticFeedback.selectionClick();
+      } else {
+        final comment = await ApiService().addComment(token, widget.postId, payload, parentId: _replyTarget?.id);
+        if (!mounted) return;
+        setState(() {
+          _insertComment(comment);
+          _submitting = false;
+          _controller.clear();
+          _replyTarget = null;
+          _pendingAttachments.clear();
+        });
+        widget.onCountChanged(_nodeById.length);
+        HapticFeedback.lightImpact();
+      }
+      FocusScope.of(context).unfocus();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _submitting = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${I18n.t(context, 'save_failed')}: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final maxHeight = MediaQuery.of(context).size.height * 0.85;
+    Widget body;
+    if (_loading) {
+      body = const Center(child: CircularProgressIndicator());
+    } else if (_error != null) {
+      body = Center(child: Text(_error!, style: theme.textTheme.bodyMedium));
+    } else if (_roots.isEmpty) {
+      body = Center(child: Text(I18n.t(context, 'no_comments_yet'), style: theme.textTheme.bodyMedium));
+    } else {
+      final items = _roots
+          .map((node) => _buildCommentWidget(theme, node, 0))
+          .toList(growable: false);
+      body = ListView.separated(
+        padding: EdgeInsets.zero,
+        itemBuilder: (context, index) => items[index],
+        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        itemCount: items.length,
+      );
+    }
+
+    return ClipRRect(
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+        child: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [
+                theme.colorScheme.surface.withOpacity(0.96),
+                theme.colorScheme.surfaceVariant.withOpacity(0.75),
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            border: Border.all(color: Colors.white.withOpacity(0.08)),
+          ),
+          padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+          child: SafeArea(
+            top: false,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxHeight: maxHeight),
+              child: Column(
+                children: [
+                  Container(
+                    width: 46,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.24),
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    children: [
+                      Text(I18n.t(context, 'comment'), style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700)),
+                      const Spacer(),
+                      IconButton(
+                        icon: const Icon(Icons.refresh),
+                        tooltip: I18n.t(context, 'reload'),
+                        onPressed: _load,
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.close),
+                        onPressed: () => Navigator.pop(context),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  Expanded(child: body),
+                  const SizedBox(height: 12),
+                  _composer(theme),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCommentWidget(ThemeData theme, _CommentNode node, int depth) {
+    final commentId = node.id;
+    final tile = _commentTile(theme, node, depth);
+    if (commentId == null || node.children.isEmpty) {
+      return tile;
+    }
+    final expanded = _expandedComments.contains(commentId);
+    final count = node.children.length;
+    final label = expanded
+        ? I18n.t(context, 'hide_replies')
+        : I18n.t(context, 'view_replies').replaceFirst('%d', '$count');
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        tile,
+        Padding(
+          padding: EdgeInsets.only(left: (depth + 1) * 20.0, top: 4),
+          child: TextButton.icon(
+            onPressed: () {
+              setState(() {
+                if (expanded) {
+                  _expandedComments.remove(commentId);
+                } else {
+                  _expandedComments.add(commentId);
+                }
+              });
+            },
+            icon: Icon(expanded ? Icons.expand_less : Icons.expand_more, size: 16),
+            label: Text(label),
+          ),
+        ),
+        AnimatedCrossFade(
+          duration: const Duration(milliseconds: 200),
+          crossFadeState: expanded ? CrossFadeState.showSecond : CrossFadeState.showFirst,
+          firstChild: const SizedBox.shrink(),
+          secondChild: Column(
+            children: [
+              const SizedBox(height: 8),
+              for (final child in node.children)
+                Padding(
+                  padding: EdgeInsets.only(left: (depth + 1) * 20.0, top: 8),
+                  child: _buildCommentWidget(theme, child, depth + 1),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _commentTile(ThemeData theme, _CommentNode node, int depth) {
+    final comment = node.data;
+    final user = (comment['user'] as Map<String, dynamic>?) ?? const {};
+    final name = (user['name'] as String?) ?? 'User';
+    final avatarUrl = widget.normalizeUrl(user['avatar'] as String?);
+    final frame = (user['frame'] as String?) ?? 'none';
+    final content = (comment['content'] as String?) ?? '';
+    final rawContent = comment['raw_content']?.toString() ?? content;
+    final attachmentsList = (comment['attachments'] as List?) ?? const [];
+    final attachments = attachmentsList
+        .whereType<Map>()
+        .map((map) => _CommentAttachment.fromMap(map.map((k, v) => MapEntry(k.toString(), v))))
+        .where((attachment) => attachment.url.isNotEmpty)
+        .toList();
+    final createdAt = widget.timeAgo(comment['created_at'] as String?);
+    final commentId = node.id;
+    final reactions = commentId != null ? _commentReactions[commentId] ?? _countsFromDynamic(comment['reactions']) : null;
+    final total = _totalReactions(reactions);
+    final userReaction = commentId != null ? _userCommentReactions[commentId] : null;
+    final visual = _visualForReaction(userReaction ?? 'like');
+    final isLoading = commentId != null && _loadingReactions.contains(commentId);
+    final ownerId = _asInt(user['id']) ?? _asInt(comment['user_id']);
+    final canManage = ownerId != null && ownerId == widget.currentUserId;
+
+    return Padding(
+      padding: EdgeInsets.only(left: depth * 20.0),
+      child: Container(
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Colors.white.withOpacity(0.08),
+              Colors.white.withOpacity(0.03),
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: Colors.white.withOpacity(0.08)),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            FramedAvatar(
+              image: avatarUrl.isNotEmpty ? NetworkImage(avatarUrl) : null,
+              name: name,
+              radius: 16,
+              frameStyle: frame,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(name, style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600)),
+                      ),
+                      Text(createdAt, style: theme.textTheme.bodySmall?.copyWith(color: theme.hintColor)),
+                      if (canManage && commentId != null)
+                        PopupMenuButton<String>(
+                          onSelected: (value) {
+                            if (value == 'edit') {
+                              setState(() {
+                                _editingCommentId = commentId;
+                                _controller.text = content;
+                                _pendingAttachments
+                                  ..clear()
+                                  ..addAll(attachments);
+                              });
+                              _focusNode.requestFocus();
+                            } else if (value == 'delete') {
+                              _deleteComment(commentId);
+                            }
+                          },
+                          itemBuilder: (context) => [
+                            PopupMenuItem(value: 'edit', child: Text(I18n.t(context, 'edit'))),
+                            PopupMenuItem(value: 'delete', child: Text(I18n.t(context, 'delete'))),
+                          ],
+                        ),
+                    ],
+                  ),
+                  if (content.isNotEmpty) ...[
+                    const SizedBox(height: 6),
+                    Text(content, style: theme.textTheme.bodyMedium),
+                  ],
+                  if (attachments.isNotEmpty) ...[
+                    SizedBox(height: content.isNotEmpty ? 10 : 6),
+                    _CommentAttachmentGallery(
+                      attachments: attachments,
+                      normalizeUrl: widget.normalizeUrl,
+                      onPreview: _openAttachmentViewer,
+                    ),
+                  ],
+                  if (commentId != null)
+                    Row(
+                      children: [
+                        _ReactionPill(
+                          leading: isLoading
+                              ? SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    valueColor: AlwaysStoppedAnimation<Color>(visual.color),
+                                  ),
+                                )
+                              : Icon(
+                                  visual.icon,
+                                  size: 16,
+                                  color: userReaction != null ? visual.color : theme.hintColor,
+                                ),
+                          label: userReaction != null ? _reactionLabel(context, userReaction) : I18n.t(context, 'like'),
+                          count: total,
+                          color: userReaction != null ? visual.color : null,
+                          active: userReaction != null,
+                          dense: true,
+                          onTap: () => _toggleCommentReaction(commentId, userReaction ?? 'like'),
+                          onLongPress: () => _openCommentReactionPicker(commentId),
+                        ),
+                        const SizedBox(width: 12),
+                        TextButton(
+                          onPressed: () {
+                            setState(() => _replyTarget = node);
+                            _focusNode.requestFocus();
+                          },
+                          style: TextButton.styleFrom(
+                            foregroundColor: theme.colorScheme.primary,
+                            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                            textStyle: theme.textTheme.labelMedium,
+                          ),
+                          child: Text(I18n.t(context, 'reply')),
+                        ),
+                      ],
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _composer(ThemeData theme) {
+    final contextNode = _editingCommentId != null
+        ? _nodeById[_editingCommentId!]
+        : _replyTarget;
+    final contextLabel = _editingCommentId != null
+        ? I18n.t(context, 'editing_comment')
+        : contextNode != null
+            ? I18n.t(context, 'replying_to').replaceFirst('%s', (contextNode.data['user'] as Map?)?['name']?.toString() ?? 'User')
+            : null;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (contextLabel != null)
+          Container(
+            margin: const EdgeInsets.only(bottom: 8),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            decoration: BoxDecoration(
+              color: Colors.white.withOpacity(0.08),
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(color: Colors.white.withOpacity(0.12)),
+            ),
+            child: Row(
+              children: [
+                Icon(_editingCommentId != null ? Icons.edit : Icons.reply, size: 16, color: theme.colorScheme.primary),
+                const SizedBox(width: 8),
+                Expanded(child: Text(contextLabel, style: theme.textTheme.labelMedium)),
+                TextButton(
+                  onPressed: () {
+                    setState(() {
+                      _replyTarget = null;
+                      _editingCommentId = null;
+                      _controller.clear();
+                      _pendingAttachments.clear();
+                    });
+                  },
+                  child: Text(I18n.t(context, 'cancel')),
+                ),
+              ],
+            ),
+          ),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(20),
+          child: BackdropFilter(
+            filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+            child: Container(
+              decoration: BoxDecoration(
+                color: Colors.white.withOpacity(0.08),
+                borderRadius: BorderRadius.circular(20),
+                border: Border.all(color: Colors.white.withOpacity(0.1)),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.emoji_emotions_outlined),
+                        tooltip: I18n.t(context, 'add_emoji'),
+                        onPressed: _showEmojiKeyboard,
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.gif_box),
+                        tooltip: I18n.t(context, 'attach_gif'),
+                        onPressed: _uploadingAttachment ? null : _pickGifAttachment,
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.image_outlined),
+                        tooltip: I18n.t(context, 'attach_photo'),
+                        onPressed: _uploadingAttachment ? null : _pickImageAttachment,
+                      ),
+                      Expanded(
+                        child: TextField(
+                          controller: _controller,
+                          focusNode: _focusNode,
+                          minLines: 1,
+                          maxLines: 4,
+                          decoration: InputDecoration(
+                            hintText: I18n.t(context, 'write_comment'),
+                            border: InputBorder.none,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      _submitting
+                          ? const SizedBox(width: 24, height: 24, child: CircularProgressIndicator(strokeWidth: 2))
+                          : IconButton(
+                              icon: const Icon(Icons.send_rounded),
+                              color: theme.colorScheme.primary,
+                              onPressed: _uploadingAttachment ? null : _submit,
+                            ),
+                    ],
+                  ),
+                  if (_pendingAttachments.isNotEmpty) ...[
+                    const SizedBox(height: 8),
+                    _ComposerAttachmentPreview(
+                      attachments: _pendingAttachments,
+                      normalizeUrl: widget.normalizeUrl,
+                      onRemove: _removePendingAttachment,
+                      onPreview: _openAttachmentViewer,
+                    ),
+                  ],
+                  if (_uploadingAttachment) ...[
+                    const SizedBox(height: 8),
+                    LinearProgressIndicator(
+                      minHeight: 3,
+                      valueColor: AlwaysStoppedAnimation(theme.colorScheme.primary),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _prefetchCommentReactions() {
+    for (final id in _nodeById.keys) {
+      unawaited(_fetchCommentReactions(id));
+    }
+  }
+
+  void _openAttachmentViewer(String url) {
+    showDialog(
+      context: context,
+      barrierColor: Colors.black.withOpacity(0.75),
+      builder: (_) => Dialog(
+        insetPadding: const EdgeInsets.all(16),
+        clipBehavior: Clip.antiAlias,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        child: InteractiveViewer(
+          minScale: 0.5,
+          maxScale: 4,
+          child: Image.network(url, fit: BoxFit.contain),
+        ),
+      ),
+    );
+  }
+
+  void _removePendingAttachment(int index) {
+    if (index < 0 || index >= _pendingAttachments.length) return;
+    setState(() {
+      _pendingAttachments.removeAt(index);
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(I18n.t(context, 'attachment_removed'))),
+    );
+  }
+
+  Future<void> _fetchCommentReactions(int commentId) async {
+    if (_loadingReactions.contains(commentId)) return;
+    if (!mounted) return;
+    setState(() => _loadingReactions.add(commentId));
+    try {
+      final data = await ApiService().getCommentReactions(commentId, token: widget.token);
+      final counts = _countsFromDynamic(data['counts']);
+      if (!mounted) return;
+      setState(() {
+        _commentReactions[commentId] = counts;
+        _userCommentReactions[commentId] = data['user_reaction'] as String?;
+        _loadingReactions.remove(commentId);
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _loadingReactions.remove(commentId));
+    }
+  }
+
+  Future<void> _toggleCommentReaction(int commentId, String reactionType) async {
+    final token = widget.token;
+    if (token == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(I18n.t(context, 'not_authenticated'))),
+      );
+      return;
+    }
+    try {
+      await ApiService().reactToComment(token, commentId, type: reactionType);
+      await _fetchCommentReactions(commentId);
+      HapticFeedback.selectionClick();
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${I18n.t(context, 'save_failed')}: $e')),
+      );
+    }
+  }
+
+  Future<void> _openCommentReactionPicker(int commentId) async {
+    final selected = await showModalBottomSheet<String>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) {
+        final theme = Theme.of(ctx);
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(26),
+            child: BackdropFilter(
+              filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      theme.colorScheme.surface.withOpacity(0.95),
+                      theme.colorScheme.surfaceVariant.withOpacity(0.78),
+                    ],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                  border: Border.all(color: Colors.white.withOpacity(0.12)),
+                ),
+                child: SafeArea(
+                  top: false,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        I18n.t(ctx, 'choose_reaction'),
+                        style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                      ),
+                      const SizedBox(height: 16),
+                      Wrap(
+                        spacing: 12,
+                        runSpacing: 12,
+                        children: [
+                          for (final type in _kReactionOrder)
+                            _ReactionChoice(
+                              visual: _visualForReaction(type),
+                              label: _reactionLabel(ctx, type),
+                              onTap: () => Navigator.of(ctx).pop(type),
+                            ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+    if (selected != null) {
+      await _toggleCommentReaction(commentId, selected);
+    }
+  }
+
+  Future<void> _pickImageAttachment() async {
+    final token = widget.token;
+    if (token == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(I18n.t(context, 'not_authenticated'))),
+      );
+      return;
+    }
+    try {
+      final file = await ImagePicker().pickImage(source: ImageSource.gallery, imageQuality: 85);
+      if (file == null) return;
+      await _uploadAttachment(token, file, _CommentAttachmentType.image);
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${I18n.t(context, 'save_failed')}: $e')),
+      );
+    }
+  }
+
+  Future<void> _pickGifAttachment() async {
+    final token = widget.token;
+    if (token == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(I18n.t(context, 'not_authenticated'))),
+      );
+      return;
+    }
+    final choice = await showModalBottomSheet<String>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: Text(I18n.t(context, 'gif_from_device')),
+              onTap: () => Navigator.pop(ctx, 'device'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.link),
+              title: Text(I18n.t(context, 'gif_from_url')),
+              onTap: () => Navigator.pop(ctx, 'url'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (choice == 'device') {
+      try {
+        final file = await ImagePicker().pickImage(source: ImageSource.gallery, imageQuality: 100);
+        if (file == null) return;
+        final name = file.name.isNotEmpty ? file.name.toLowerCase() : file.path.toLowerCase();
+        if (!name.endsWith('.gif')) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(I18n.t(context, 'invalid_gif'))),
+          );
+          return;
+        }
+        await _uploadAttachment(token, file, _CommentAttachmentType.gif);
+      } catch (e) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('${I18n.t(context, 'save_failed')}: $e')),
+        );
+      }
+    } else if (choice == 'url') {
+      final url = await _promptGifUrl();
+      if (url == null) return;
+      setState(() {
+        _pendingAttachments.add(_CommentAttachment(_CommentAttachmentType.gif, url));
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(I18n.t(context, 'attachment_added'))),
+      );
+    }
+  }
+
+  Future<String?> _promptGifUrl() async {
+    final controller = TextEditingController();
+    final result = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(I18n.t(context, 'attach_gif')),
+        content: TextField(
+          controller: controller,
+          keyboardType: TextInputType.url,
+          decoration: InputDecoration(hintText: I18n.t(context, 'gif_url_hint')),
+          autofocus: true,
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx), child: Text(I18n.t(context, 'cancel'))),
+          FilledButton(onPressed: () => Navigator.pop(ctx, controller.text.trim()), child: Text(I18n.t(context, 'save'))),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (result == null || result.trim().isEmpty) return null;
+    final uri = Uri.tryParse(result.trim());
+    if (uri == null || (!uri.isScheme('http') && !uri.isScheme('https'))) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(I18n.t(context, 'invalid_gif_url'))),
+      );
+      return null;
+    }
+    return result.trim();
+  }
+
+  Future<void> _uploadAttachment(String token, XFile file, _CommentAttachmentType type) async {
+    setState(() => _uploadingAttachment = true);
+    try {
+      String url;
+      if (kIsWeb) {
+        final bytes = await file.readAsBytes();
+        url = await ApiService().uploadCommentMediaBytes(token, bytes, filename: file.name.isNotEmpty ? file.name : 'attachment');
+      } else {
+        url = await ApiService().uploadCommentMedia(token, file.path, filename: file.name.isNotEmpty ? file.name : null);
+      }
+      if (!mounted) return;
+      setState(() {
+        _pendingAttachments.add(_CommentAttachment(type, url));
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(I18n.t(context, 'attachment_added'))),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${I18n.t(context, 'attachment_upload_failed')}: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _uploadingAttachment = false);
+      }
+    }
+  }
+
+  Future<void> _showEmojiKeyboard() async {
+    FocusScope.of(context).requestFocus(_focusNode);
+    await SystemChannels.textInput.invokeMethod('TextInput.show');
+  }
+
+  void _toastUnavailable() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(I18n.t(context, 'coming_soon'))),
+    );
+  }
+  
+}
+
+class _ComposerAvatar {
+  const _ComposerAvatar(this.img, this.initials, this.frame);
+  final ImageProvider? img;
+  final String initials;
+  final String frame;
+}
+
+class _CommentNode {
+  _CommentNode(Map<String, dynamic> data) : data = Map<String, dynamic>.from(data);
+
+  Map<String, dynamic> data;
+  final List<_CommentNode> children = [];
+
+  int? get id => (data['id'] as num?)?.toInt();
+  int? get parentId => (data['parent_id'] as num?)?.toInt();
+}
+
+enum _CommentAttachmentType { image, gif }
+
+class _CommentAttachment {
+  const _CommentAttachment(this.type, this.url);
+
+  final _CommentAttachmentType type;
+  final String url;
+
+  Map<String, dynamic> toMap() => {'type': type.name, 'url': url};
+
+  static _CommentAttachment fromMap(Map<String, dynamic> map) {
+    final typeName = map['type']?.toString() ?? 'image';
+    final url = map['url']?.toString() ?? '';
+    final type = _CommentAttachmentType.values.firstWhere(
+      (t) => t.name == typeName,
+      orElse: () => _CommentAttachmentType.image,
+    );
+    return _CommentAttachment(type, url);
+  }
+}
+
+class _ParsedCommentContent {
+  const _ParsedCommentContent({required this.text, required this.attachments});
+
+  final String text;
+  final List<_CommentAttachment> attachments;
+}
+
+_ParsedCommentContent _splitCommentContent(String raw) {
+  if (raw.isEmpty) {
+    return const _ParsedCommentContent(text: '', attachments: []);
+  }
+  final attachments = <_CommentAttachment>[];
+  final buffer = <String>[];
+  for (final line in raw.split('\n')) {
+    final trimmed = line.trim();
+    if (trimmed.startsWith(_kCommentAttachmentPrefix)) {
+      final payload = trimmed.substring(_kCommentAttachmentPrefix.length);
+      final separatorIndex = payload.indexOf('|');
+      if (separatorIndex >= 0) {
+        final typeName = payload.substring(0, separatorIndex);
+        final url = payload.substring(separatorIndex + 1).trim();
+        if (url.isNotEmpty) {
+          final type = _CommentAttachmentType.values.firstWhere(
+            (t) => t.name == typeName,
+            orElse: () => _CommentAttachmentType.image,
+          );
+          attachments.add(_CommentAttachment(type, url));
+          continue;
+        }
+      }
+    }
+    buffer.add(line);
+  }
+  final text = buffer.join('\n').trim();
+  return _ParsedCommentContent(text: text, attachments: attachments);
+}
+
+class AnimatedLikeIcon extends StatefulWidget {
+  const AnimatedLikeIcon({super.key, required this.active});
+
+  final bool active;
+
+  @override
+  State<AnimatedLikeIcon> createState() => _AnimatedLikeIconState();
+}
+
+class _AnimatedLikeIconState extends State<AnimatedLikeIcon> with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 220),
+    );
+    _scale = Tween<double>(begin: 1.0, end: 1.12).animate(
+      CurvedAnimation(
+        parent: _controller,
+        curve: Curves.easeOutBack,
+        reverseCurve: Curves.easeIn,
+      ),
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant AnimatedLikeIcon oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.active != widget.active) {
+      _controller.forward(from: 0).then((_) {
+        if (mounted) {
+          _controller.reverse();
+        }
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = widget.active ? Theme.of(context).colorScheme.primary : Theme.of(context).iconTheme.color;
+    return ScaleTransition(
+      scale: _scale,
+      child: Icon(widget.active ? Icons.thumb_up_alt : Icons.thumb_up_alt_outlined, size: 18, color: color),
+    );
+  }
+}
+class _PostMetaPill extends StatelessWidget {
+  const _PostMetaPill({
+    required this.icon,
+    required this.label,
+    required this.color,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(14),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            color.withOpacity(0.20),
+            color.withOpacity(0.10),
+          ],
+        ),
+        border: Border.all(color: color.withOpacity(0.35), width: 1),
+        boxShadow: [
+          BoxShadow(
+            color: color.withOpacity(0.18),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: color),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: color,
+              fontWeight: FontWeight.w600,
+              height: 1.1,
+            ),
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PostMetaInfoChip extends StatelessWidget {
+  const _PostMetaInfoChip({
+    required this.icon,
+    required this.label,
+    this.trailing,
+  });
+
+  final IconData icon;
+  final String label;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final effectiveLabel = label.isEmpty ? '—' : label;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(14),
+        color: Colors.white.withOpacity(0.06),
+        border: Border.all(color: Colors.white.withOpacity(0.12)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: theme.hintColor),
+          const SizedBox(width: 6),
+          Text(
+            effectiveLabel,
+            style: theme.textTheme.labelMedium?.copyWith(color: theme.hintColor),
+          ),
+          if (trailing != null) ...[
+            const SizedBox(width: 6),
+            trailing!,
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _PostBodyBlock extends StatelessWidget {
+  const _PostBodyBlock({required this.text, this.palette});
+
+  final String text;
+  final List<Color>? palette;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasPalette = palette != null && palette!.isNotEmpty;
+    final decoration = BoxDecoration(
+      borderRadius: BorderRadius.circular(20),
+      gradient: hasPalette
+          ? LinearGradient(colors: palette!, begin: Alignment.topLeft, end: Alignment.bottomRight)
+          : null,
+      color: hasPalette ? null : Colors.white.withOpacity(0.05),
+      border: Border.all(color: Colors.white.withOpacity(hasPalette ? 0.18 : 0.08)),
+      boxShadow: hasPalette
+          ? [
+              BoxShadow(
+                color: palette!.last.withOpacity(0.25),
+                blurRadius: 20,
+                offset: const Offset(0, 12),
+              ),
+            ]
+          : null,
+    );
+
+    final textStyle = hasPalette
+        ? theme.textTheme.bodyMedium?.copyWith(
+              color: Colors.white,
+              height: 1.5,
+              fontWeight: FontWeight.w500,
+            )
+        : theme.textTheme.bodyMedium?.copyWith(height: 1.5);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 16),
+      decoration: decoration,
+      child: Text(text, style: textStyle),
+    );
+  }
+}

--- a/lib/profil/profile_page.dart
+++ b/lib/profil/profile_page.dart
@@ -1063,7 +1063,7 @@ class _ProfilePageState extends State<ProfilePage> with SingleTickerProviderStat
                                         await _persistDraft();
                                       },
                                       child: Container(
-                                        padding: const EdgeInsets.all(8),
+                                        padding: const EdgeInsets.all(10),
                                         decoration: BoxDecoration(
                                           color: Colors.white.withOpacity(0.08),
                                           borderRadius: BorderRadius.circular(16),
@@ -1075,8 +1075,8 @@ class _ProfilePageState extends State<ProfilePage> with SingleTickerProviderStat
                                           ),
                                         ),
                                         child: SizedBox(
-                                          width: 64,
-                                          height: 64,
+                                          width: 78,
+                                          height: 78,
                                           child: sticker.asset != null
                                               ? Image.asset('assets/stickers/${sticker.asset!}', fit: BoxFit.contain)
                                               : Image.network(sticker.url!, fit: BoxFit.contain),

--- a/lib/profil/profile_page.dart
+++ b/lib/profil/profile_page.dart
@@ -1,0 +1,1675 @@
+library profile_page;
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../services/sticker_service.dart';
+import '../utils/i18n.dart';
+import '../utils/ui_utils.dart';
+import 'frame_preview_strip.dart';
+import 'framed_avatar.dart';
+import 'models/profile_models.dart';
+import 'note_editor.dart' show NoteEditResult, showEmojiPickerSheet;
+import 'note_editor_page.dart';
+import 'note_overlay.dart';
+import 'services/profile_repository.dart';
+
+part 'completion_card.dart';
+part 'halo_painter.dart';
+part 'countdown_ring_painter.dart';
+part 'quick_action_button.dart';
+part 'frame_picker_sheet.dart';
+part 'avatar_viewer.dart';
+
+class ProfilePage extends StatefulWidget {
+  const ProfilePage({super.key});
+
+  @override
+  State<ProfilePage> createState() => _ProfilePageState();
+}
+
+class _ProfilePageState extends State<ProfilePage> with SingleTickerProviderStateMixin {
+  final ImagePicker _picker = ImagePicker();
+
+  late final AnimationController _haloCtrl;
+  late final TextEditingController _nameCtrl;
+  late final TextEditingController _descCtrl;
+
+  ProfileRepository? _repository;
+  ProfileData _data = ProfileData.initial();
+
+  bool _loading = true;
+  bool _saving = false;
+  bool _dirty = false;
+  bool _syncingText = false;
+
+  Timer? _nameDebounce;
+  Timer? _descDebounce;
+  Timer? _statusTicker;
+  Timer? _autoSaveTimer;
+
+  String? _frameTempPreview;
+  List<Sticker> _stickers = const [];
+
+  static const List<String> kFrameStyles = [
+    'none',
+    'glow-00E676',
+    'glow-03A9F4',
+    'glow-FF5252',
+    'glow-AB47BC',
+    'neon-00FF9C',
+    'neon-FFEA00',
+    'neon-FF3D00',
+    'neon-00E5FF',
+    'neon-7C4DFF',
+    'outline-42A5F5',
+    'outline-FF7043',
+    'outline-66BB6A',
+    'outline-EC407A',
+    'outline-FFC107',
+    'ring-1DE9B6',
+    'ring-E040FB',
+    'ring-FF6E40',
+    'ring-29B6F6',
+    'ring-AED581',
+    'gradient-sunset',
+    'gradient-ocean',
+    'gradient-forest',
+    'gradient-violet',
+    'gradient-fire',
+    'gradient-candy',
+    'gradient-berry',
+    'gradient-sky',
+    'gradient-mint',
+    'gradient-royal',
+    'gradient-rose',
+    'gradient-aurora',
+    'gradient-citrus',
+    'gradient-plasma',
+    'gradient-peach',
+    'gradient-lava',
+    'gradient-aqua',
+    'gradient-steel',
+    'gradient-gold',
+    'gradient-silver',
+    'gradient-bronze',
+    'rainbow',
+    'glow-FF4081',
+    'glow-8BC34A',
+    'neon-18FFFF',
+    'neon-E040FB',
+    'outline-90CAF9',
+    'outline-FFAB91',
+    'ring-80CBC4',
+    'ring-CE93D8',
+  ];
+
+  static const Map<String, List<String>> _kCategories = {
+    'All': [],
+    'Gradients': ['gradient-', 'rainbow'],
+    'Glow': ['glow-'],
+    'Neon': ['neon-'],
+    'Outline': ['outline-'],
+    'Ring': ['ring-'],
+    'Other': ['none'],
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    _nameCtrl = TextEditingController();
+    _descCtrl = TextEditingController();
+    _haloCtrl = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 18),
+    )..repeat();
+
+    _nameCtrl.addListener(_handleNameChanged);
+    _descCtrl.addListener(_handleDescriptionChanged);
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    final repository = await ProfileRepository.create();
+    final data = await repository.loadProfile();
+    if (!mounted) return;
+    setState(() {
+      _repository = repository;
+      _data = data;
+      _loading = false;
+    });
+    _applyTextControllers();
+    if (_data.preferences.reduceMotion) {
+      _haloCtrl.stop();
+    } else if (!_haloCtrl.isAnimating) {
+      _haloCtrl.repeat();
+    }
+    _startStatusTicker();
+  }
+
+  void _applyTextControllers() {
+    _syncingText = true;
+    _nameCtrl.text = _data.name;
+    _descCtrl.text = _data.description;
+    _syncingText = false;
+  }
+
+  @override
+  void dispose() {
+    _nameDebounce?.cancel();
+    _descDebounce?.cancel();
+    _statusTicker?.cancel();
+    _autoSaveTimer?.cancel();
+    _haloCtrl.dispose();
+    _nameCtrl.removeListener(_handleNameChanged);
+    _descCtrl.removeListener(_handleDescriptionChanged);
+    _nameCtrl.dispose();
+    _descCtrl.dispose();
+    super.dispose();
+  }
+
+  void _handleNameChanged() {
+    if (_syncingText) return;
+    final value = _nameCtrl.text;
+    _nameDebounce?.cancel();
+    setState(() {
+      _data = _data.copyWith(name: value);
+    });
+    _markDirty();
+    _nameDebounce = Timer(const Duration(milliseconds: 350), () {
+      _repository?.persistName(value);
+    });
+  }
+
+  void _handleDescriptionChanged() {
+    if (_syncingText) return;
+    final value = _descCtrl.text;
+    _descDebounce?.cancel();
+    setState(() {
+      _data = _data.copyWith(description: value);
+    });
+    _markDirty();
+    _descDebounce = Timer(const Duration(milliseconds: 500), () {
+      _repository?.persistDescription(value);
+    });
+  }
+
+  void _markDirty() {
+    if (!_data.isAuthenticated) return;
+    if (!_dirty) {
+      setState(() => _dirty = true);
+    }
+    _scheduleAutoSave();
+  }
+
+  void _scheduleAutoSave() {
+    if (!_data.isAuthenticated) return;
+    _autoSaveTimer?.cancel();
+    _autoSaveTimer = Timer(const Duration(seconds: 1), () {
+      if (!mounted) return;
+      if (_dirty && !_saving) {
+        _saveProfileToServer(silent: true);
+      }
+    });
+  }
+
+  Future<void> _persistDraft() async {
+    final repo = _repository;
+    if (repo == null) return;
+    await repo.persistDraft(_data);
+    _markDirty();
+  }
+
+  void _startStatusTicker() {
+    _statusTicker?.cancel();
+    if (!_data.status.isActive) return;
+    _statusTicker = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (!mounted) return;
+      setState(() {});
+      if (!_data.status.isActive) {
+        _statusTicker?.cancel();
+      }
+    });
+  }
+
+  double get _statusProgress {
+    final status = _data.status;
+    if (!status.isActive || status.expiresAt == null) return 0;
+    final end = status.expiresAt!;
+    final start = end.subtract(const Duration(hours: 24));
+    final now = DateTime.now();
+    final total = end.difference(start).inMilliseconds.toDouble();
+    final done = (now.isBefore(start)
+            ? 0
+            : now.difference(start).inMilliseconds.toDouble())
+        .clamp(0, total);
+    if (total <= 0) return 0;
+    return done / total;
+  }
+
+  Future<void> _refreshProfile() async {
+    final repo = _repository ?? await ProfileRepository.create();
+    final updated = await repo.loadProfile();
+    if (!mounted) return;
+    setState(() {
+      _repository = repo;
+      _data = updated;
+      _dirty = false;
+    });
+    _applyTextControllers();
+    if (_data.preferences.reduceMotion) {
+      _haloCtrl.stop();
+    } else if (!_haloCtrl.isAnimating) {
+      _haloCtrl.repeat();
+    }
+    _startStatusTicker();
+  }
+
+  Future<void> _revertLocal() async {
+    final repo = _repository;
+    if (repo == null) return;
+    final local = await ProfileData.fromPrefsAsync(repo.prefs);
+    if (!mounted) return;
+    setState(() {
+      _data = local.copyWith(authToken: _data.authToken);
+      _dirty = false;
+    });
+    _applyTextControllers();
+    _startStatusTicker();
+  }
+
+  Future<void> _saveProfileToServer({bool silent = false}) async {
+    final repo = _repository;
+    if (repo == null || !_data.isAuthenticated) {
+      if (!silent) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(I18n.t(context, 'not_authenticated'))),
+        );
+      }
+      return;
+    }
+    if (_saving) return;
+    setState(() => _saving = true);
+    try {
+      final snapshot = _data.copyWith(
+        name: _nameCtrl.text,
+        description: _descCtrl.text,
+      );
+      final updated = await repo.saveProfile(snapshot);
+      if (!mounted) return;
+      setState(() {
+        _data = updated;
+        _dirty = false;
+      });
+      if (!silent) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(I18n.t(context, 'profile_saved'))),
+        );
+        HapticFeedback.mediumImpact();
+      }
+    } on ProfileAuthException {
+      if (!silent) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(I18n.t(context, 'not_authenticated'))),
+        );
+      }
+    } catch (e) {
+      if (!silent) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('${I18n.t(context, 'save_failed')}: $e')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _saving = false);
+      }
+    }
+  }
+
+  Future<void> _saveAvatarFromXFile(XFile file) async {
+    final repo = _repository ?? await ProfileRepository.create();
+    try {
+      final updated = await repo.saveAvatar(
+        _data.copyWith(authToken: _data.authToken ?? repo.prefs.getString('auth_token')),
+        file,
+      );
+      if (!mounted) return;
+      setState(() => _data = updated);
+      _repository = repo;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(I18n.t(context, 'avatar_updated'))),
+      );
+      HapticFeedback.selectionClick();
+      if (_data.preferences.reduceMotion) {
+        _haloCtrl.stop();
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${I18n.t(context, 'upload_error')}: $e')),
+      );
+    }
+  }
+
+  Future<void> _clearAvatar() async {
+    final repo = _repository ?? await ProfileRepository.create();
+    try {
+      final updated = await repo.clearAvatar(_data);
+      if (!mounted) return;
+      setState(() => _data = updated);
+      _repository = repo;
+      HapticFeedback.lightImpact();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${I18n.t(context, 'avatar_delete_failed')}: $e')),
+      );
+    }
+  }
+
+  Future<void> _saveBannerFromXFile(XFile file) async {
+    final repo = _repository ?? await ProfileRepository.create();
+    try {
+      final updated = await repo.saveBanner(
+        _data.copyWith(authToken: _data.authToken ?? repo.prefs.getString('auth_token')),
+        file,
+      );
+      if (!mounted) return;
+      setState(() => _data = updated);
+      _repository = repo;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(I18n.t(context, 'banner_updated'))),
+      );
+      HapticFeedback.selectionClick();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${I18n.t(context, 'upload_error')}: $e')),
+      );
+    }
+  }
+
+  Future<void> _clearBanner() async {
+    final repo = _repository ?? await ProfileRepository.create();
+    try {
+      final updated = await repo.clearBanner(_data);
+      if (!mounted) return;
+      setState(() => _data = updated);
+      _repository = repo;
+      HapticFeedback.lightImpact();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${I18n.t(context, 'banner_delete_failed')}: $e')),
+      );
+    }
+  }
+
+  void _setFrame(String style) {
+    setState(() => _data = _data.copyWith(avatarFrame: style));
+    _persistDraft();
+    HapticFeedback.selectionClick();
+  }
+
+  void _cycleFrame(int dir) {
+    final list = kFrameStyles;
+    final idx = list.indexOf(_data.avatarFrame);
+    final next = (idx < 0 ? 0 : idx + dir) % list.length;
+    final selection = list[(next + list.length) % list.length];
+    _setFrame(selection);
+  }
+
+  void _randomizeFrame() {
+    final pool = kFrameStyles.where((e) => e != 'none').toList()..shuffle();
+    if (pool.isEmpty) return;
+    _setFrame(pool.first);
+  }
+
+  Future<void> _openFramePickerSheet() async {
+    final selected = await showModalBottomSheet<String>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => _FramePickerSheet(
+        allStyles: kFrameStyles,
+        current: _data.avatarFrame,
+        favs: _data.preferences.frameFavorites,
+        categories: _kCategories,
+        colorsFor: _colorsForFrame,
+        onPreviewStart: (style) => setState(() => _frameTempPreview = style),
+        onPreviewEnd: () => setState(() => _frameTempPreview = null),
+        onToggleFav: (style) async {
+          final currentFavs = _data.preferences.frameFavorites.toSet();
+          if (currentFavs.contains(style)) {
+            currentFavs.remove(style);
+          } else {
+            currentFavs.add(style);
+          }
+          setState(() {
+            _data = _data.copyWith(
+              preferences: _data.preferences.copyWith(frameFavorites: currentFavs),
+            );
+          });
+          await _persistDraft();
+        },
+      ),
+    );
+    if (selected != null && selected.isNotEmpty) {
+      _setFrame(selected);
+    }
+  }
+
+  Future<void> _showBannerOptions() async {
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (_) => SafeArea(
+        child: Wrap(
+          children: [
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: Text(I18n.t(context, 'pick_from_gallery')),
+              onTap: () async {
+                Navigator.of(context).pop();
+                await _pickBannerImage(ImageSource.gallery);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.camera_alt),
+              title: Text(I18n.t(context, 'take_photo')),
+              onTap: () async {
+                Navigator.of(context).pop();
+                await _pickBannerImage(ImageSource.camera);
+              },
+            ),
+            if (_data.banner.hasImage)
+              ListTile(
+                leading: const Icon(Icons.delete),
+                title: Text(I18n.t(context, 'delete_banner')),
+                onTap: () {
+                  Navigator.of(context).pop();
+                  _clearBanner();
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickBannerImage(ImageSource source) async {
+    try {
+      final file = await _picker.pickImage(
+        source: source,
+        maxWidth: 1920,
+        maxHeight: 1080,
+        imageQuality: 85,
+      );
+      if (file != null) {
+        await _saveBannerFromXFile(file);
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Eroare la incarcare banner: $e')),
+      );
+    }
+  }
+
+  void _showImageOptions() {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (_) => SafeArea(
+        child: Wrap(
+          children: [
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: Text(I18n.t(context, 'pick_from_gallery')),
+              onTap: () {
+                Navigator.of(context).pop();
+                _pickImage(ImageSource.gallery);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.camera_alt),
+              title: Text(I18n.t(context, 'take_photo')),
+              onTap: () {
+                Navigator.of(context).pop();
+                _pickImage(ImageSource.camera);
+              },
+            ),
+            if (_data.avatar.hasImage)
+              ListTile(
+                leading: const Icon(Icons.delete),
+                title: Text(I18n.t(context, 'delete_avatar')),
+                onTap: () {
+                  Navigator.of(context).pop();
+                  _clearAvatar();
+                },
+              ),
+            if (_currentAvatarImage() != null)
+              ListTile(
+                leading: const Icon(Icons.zoom_out_map),
+                title: Text(I18n.t(context, 'zoom_avatar')),
+                onTap: () {
+                  Navigator.of(context).pop();
+                  _openAvatarViewer();
+                },
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickImage(ImageSource source) async {
+    try {
+      final file = await _picker.pickImage(
+        source: source,
+        maxWidth: 1200,
+        maxHeight: 1200,
+        imageQuality: 85,
+      );
+      if (file != null) {
+        await _saveAvatarFromXFile(file);
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${I18n.t(context, 'image_load_error')}: $e')),
+      );
+    }
+  }
+
+  Future<void> _editStatusNote() async {
+    final result = await Navigator.of(context).push<NoteEditResult>(
+      MaterialPageRoute(
+        fullscreenDialog: true,
+        builder: (_) => NoteEditorPage(
+          initialText: _data.status.text ?? '',
+          textColor: _data.status.textColor,
+          bgColor: _data.status.backgroundColor,
+          emoji: _data.status.emoji,
+          avatarImage: _currentAvatarImage(),
+          avatarName: _nameCtrl.text.trim().isEmpty ? 'User' : _nameCtrl.text.trim(),
+          frameStyle: _data.avatarFrame,
+        ),
+      ),
+    );
+    if (result == null) return;
+    if (result.deleted || result.text?.trim().isEmpty == true) {
+      setState(() {
+        _data = _data.copyWith(status: const StatusNote(text: null, expiresAt: null, emoji: null));
+      });
+      await _persistDraft();
+      _statusTicker?.cancel();
+      return;
+    }
+    final exp = DateTime.now().add(const Duration(hours: 24));
+    setState(() {
+      _data = _data.copyWith(
+        status: StatusNote(
+          text: result.text?.trim(),
+          expiresAt: exp,
+          textColor: result.textColor,
+          backgroundColor: result.bgColor,
+          emoji: _data.status.emoji,
+        ),
+      );
+    });
+    await _persistDraft();
+    _startStatusTicker();
+  }
+
+  Future<void> _pickEmoji() async {
+    final emoji = await showEmojiPickerSheet(context);
+    if (emoji == null) return;
+    setState(() {
+      _data = _data.copyWith(
+        status: _data.status.copyWith(emoji: emoji.isEmpty ? null : emoji),
+      );
+    });
+    await _persistDraft();
+  }
+
+  Future<void> _saveLink(String key, String? value) async {
+    SocialLinks updated;
+    switch (key) {
+      case 'profile_facebook':
+        updated = _data.social.copyWith(facebook: value);
+        break;
+      case 'profile_instagram':
+        updated = _data.social.copyWith(instagram: value);
+        break;
+      case 'profile_tiktok':
+        updated = _data.social.copyWith(tiktok: value);
+        break;
+      case 'profile_youtube':
+        updated = _data.social.copyWith(youtube: value);
+        break;
+      default:
+        updated = _data.social;
+    }
+    setState(() => _data = _data.copyWith(social: updated));
+    await _persistDraft();
+  }
+
+  Future<void> _editLinkDialog(String title, String prefKey, String? current) async {
+    final controller = TextEditingController(text: current ?? '');
+    await showDialog<void>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text('${I18n.t(context, 'edit')}: $title'),
+          content: TextField(
+            controller: controller,
+            keyboardType: TextInputType.url,
+            textInputAction: TextInputAction.done,
+            decoration: const InputDecoration(
+              hintText: 'Link sau @handle (ex. https://..., @user, user)',
+            ),
+            onSubmitted: (_) => Navigator.of(context).maybePop(),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: Text(I18n.t(context, 'cancel')),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                final raw = controller.text.trim();
+                final normalized = _normalizeLinkForBrand(prefKey, raw);
+                _saveLink(prefKey, normalized.isEmpty ? null : normalized);
+                Navigator.of(context).pop();
+                HapticFeedback.selectionClick();
+              },
+              child: Text(I18n.t(context, 'save')),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  String _normalizeLinkForBrand(String prefKey, String input) {
+    final value = input.trim();
+    if (value.isEmpty) return '';
+    final isUrl = value.startsWith('http://') || value.startsWith('https://');
+    final username = value.startsWith('@') ? value.substring(1) : value;
+    if (isUrl) return value;
+    switch (prefKey) {
+      case 'profile_facebook':
+        return 'https://facebook.com/$username';
+      case 'profile_instagram':
+        return 'https://instagram.com/$username';
+      case 'profile_tiktok':
+        if (username.contains('/')) return 'https://tiktok.com/$username';
+        return 'https://www.tiktok.com/@$username';
+      case 'profile_youtube':
+        if (username.startsWith('@')) return 'https://youtube.com/$username';
+        if (username.startsWith('UC')) return 'https://youtube.com/channel/$username';
+        return 'https://youtube.com/@$username';
+      default:
+        return value;
+    }
+  }
+
+  Future<void> _openLink(String? url) async {
+    if (url == null || url.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Nu exista link setat pentru acest serviciu.')),
+      );
+      return;
+    }
+    final uri = Uri.tryParse(url);
+    if (uri == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('URL invalid.')),
+      );
+      return;
+    }
+    if (!await canLaunchUrl(uri)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Nu s-a putut deschide linkul.')),
+      );
+      return;
+    }
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  Widget _socialButton(String brand, IconData icon, String? link, String title, String prefKey) {
+    final enabled = link != null && link.isNotEmpty;
+    BoxDecoration decoFor(String b) {
+      switch (b) {
+        case 'facebook':
+          const base = Color(0xFF1877F2);
+          return BoxDecoration(
+            color: enabled ? base : Colors.grey,
+            shape: BoxShape.circle,
+            boxShadow: enabled
+                ? [BoxShadow(color: base.withOpacity(0.35), blurRadius: 12, offset: const Offset(0, 4))]
+                : [],
+          );
+        case 'instagram':
+          return BoxDecoration(
+            shape: BoxShape.circle,
+            gradient: enabled
+                ? const LinearGradient(
+                    colors: [
+                      Color(0xFFF58529),
+                      Color(0xFFDD2A7B),
+                      Color(0xFF8134AF),
+                      Color(0xFF515BD4),
+                    ],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  )
+                : LinearGradient(colors: [Colors.grey.shade700, Colors.grey.shade600]),
+            boxShadow: enabled ? [const BoxShadow(color: Color(0x55212121), blurRadius: 10, offset: Offset(0, 4))] : [],
+          );
+        case 'tiktok':
+          return BoxDecoration(
+            color: enabled ? Colors.black : Colors.grey,
+            shape: BoxShape.circle,
+            boxShadow: enabled
+                ? [
+                    BoxShadow(color: const Color(0xFF69C9D0).withOpacity(0.4), blurRadius: 10, offset: const Offset(-2, 2)),
+                    BoxShadow(color: const Color(0xFFEE1D52).withOpacity(0.4), blurRadius: 10, offset: const Offset(2, 2)),
+                  ]
+                : [],
+          );
+        case 'youtube':
+          const base = Color(0xFFFF0000);
+          return BoxDecoration(
+            color: enabled ? base : Colors.grey,
+            shape: BoxShape.circle,
+            boxShadow: enabled ? [BoxShadow(color: base.withOpacity(0.35), blurRadius: 12, offset: const Offset(0, 4))] : [],
+          );
+        default:
+          return BoxDecoration(color: enabled ? Colors.blueAccent : Colors.grey, shape: BoxShape.circle);
+      }
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Semantics(
+          button: true,
+          label: enabled ? '$title megnyitása' : '$title nincs beállítva',
+          child: GestureDetector(
+            onTap: enabled
+                ? () {
+                    _openLink(link);
+                    HapticFeedback.selectionClick();
+                  }
+                : null,
+            onLongPress: enabled
+                ? () async {
+                    await Clipboard.setData(ClipboardData(text: link));
+                    if (mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(I18n.t(context, 'link_copied'))),
+                      );
+                    }
+                    HapticFeedback.lightImpact();
+                  }
+                : null,
+            child: AnimatedScale(
+              duration: const Duration(milliseconds: 120),
+              scale: enabled ? 1.0 : 0.95,
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                width: 56,
+                height: 56,
+                decoration: decoFor(brand),
+                alignment: Alignment.center,
+                child: FaIcon(icon, color: Colors.white, size: 26),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 6),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.edit, size: 18),
+              onPressed: () => _editLinkDialog(title, prefKey, link),
+              tooltip: I18n.t(context, 'edit_link'),
+            ),
+            IconButton(
+              icon: const Icon(Icons.open_in_new, size: 18),
+              onPressed: enabled ? () => _openLink(link) : null,
+              tooltip: I18n.t(context, 'open_link'),
+            ),
+          ],
+        )
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    final theme = Theme.of(context);
+    final width = MediaQuery.of(context).size.width;
+    final textScale = MediaQuery.of(context).textScaleFactor.clamp(0.9, 1.2);
+    final isSmall = width < 420;
+    final avatarRadius = isSmall ? 48.0 : 60.0;
+    final bubbleSpace = isSmall ? 44.0 : 52.0;
+    final tileWidth = (avatarRadius * 2) + (isSmall ? 160.0 : 220.0);
+    final bubbleRightInset = (tileWidth / 2) - avatarRadius - 4;
+    final name = _nameCtrl.text.trim();
+    final completeness = _data.completeness;
+
+    return WillPopScope(
+      onWillPop: _onBackPressed,
+      child: MediaQuery(
+        data: MediaQuery.of(context).copyWith(textScaler: TextScaler.linear(textScale)),
+        child: Scaffold(
+          backgroundColor: Colors.transparent,
+          appBar: AppBar(
+            title: Text(I18n.t(context, 'profile')),
+            backgroundColor: Colors.transparent,
+            surfaceTintColor: Colors.transparent,
+            elevation: 0,
+            scrolledUnderElevation: 0,
+            toolbarHeight: 68,
+            flexibleSpace: Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [
+                    theme.colorScheme.surface.withOpacity(0.92),
+                    theme.colorScheme.surface.withOpacity(0.78),
+                  ],
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                ),
+              ),
+            ),
+          ),
+          body: DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [
+                  theme.colorScheme.surfaceVariant.withOpacity(0.75),
+                  theme.colorScheme.surface.withOpacity(0.92),
+                  theme.colorScheme.surface.withOpacity(0.98),
+                ],
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+              ),
+            ),
+            child: RefreshIndicator(
+              onRefresh: _refreshProfile,
+              child: SingleChildScrollView(
+                keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: EdgeInsets.fromLTRB(isSmall ? 12 : 20, 16, isSmall ? 12 : 20, 24),
+                child: Column(
+                  children: [
+                    _buildHeroSection(theme, isSmall, avatarRadius, name),
+                    const SizedBox(height: 24),
+                    Align(
+                      alignment: Alignment.center,
+                      child: Wrap(
+                        alignment: WrapAlignment.center,
+                        spacing: 12,
+                        runSpacing: 8,
+                        children: [
+                          _QuickActionButton(
+                            icon: Icons.brush_outlined,
+                            label: 'Rame',
+                            onTap: _openFramePickerSheet,
+                          ),
+                          _QuickActionButton(
+                            icon: Icons.casino_outlined,
+                            label: 'Random',
+                            onTap: _randomizeFrame,
+                          ),
+                          _QuickActionButton(
+                            icon: Icons.edit_note_outlined,
+                            label: I18n.t(context, 'add_status'),
+                            onTap: _editStatusNote,
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    _CompletionCard(percent: completeness),
+                    const SizedBox(height: 16),
+                    _glassField(
+                      child: TextField(
+                        controller: _nameCtrl,
+                        textInputAction: TextInputAction.next,
+                        decoration: const InputDecoration(
+                          labelText: 'Nume',
+                          border: OutlineInputBorder(),
+                          prefixIcon: Icon(Icons.person_outline),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    _glassField(
+                      child: TextField(
+                        controller: _descCtrl,
+                        maxLines: 4,
+                        textInputAction: TextInputAction.newline,
+                        decoration: const InputDecoration(
+                          labelText: 'Descriere',
+                          border: OutlineInputBorder(),
+                          alignLabelWithHint: true,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text('Rama avatar', style: theme.textTheme.titleMedium),
+                    ),
+                    const SizedBox(height: 8),
+                    FramePreviewStrip(
+                      styles: kFrameStyles,
+                      selected: _data.avatarFrame,
+                      image: _currentAvatarImage(),
+                      name: name,
+                      onSelected: _setFrame,
+                    ),
+                    const SizedBox(height: 16),
+                    _glassField(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            children: [
+                              const Icon(Icons.auto_fix_high, size: 18),
+                              const SizedBox(width: 8),
+                              const Text('Puterea haloului'),
+                              const Spacer(),
+                              Text('${(_data.preferences.haloStrength * 100).round()}%'),
+                            ],
+                          ),
+                          Slider(
+                            value: _data.preferences.haloStrength,
+                            onChanged: (v) => setState(() =>
+                                _data = _data.copyWith(preferences: _data.preferences.copyWith(haloStrength: v))),
+                            onChangeEnd: (_) => _persistDraft(),
+                          ),
+                          const SizedBox(height: 6),
+                          SwitchListTile(
+                            dense: true,
+                            contentPadding: EdgeInsets.zero,
+                            title: const Text('Reduce motion (efecte minime)'),
+                            value: _data.preferences.reduceMotion,
+                            onChanged: (value) {
+                              setState(() {
+                                _data = _data.copyWith(
+                                  preferences: _data.preferences.copyWith(reduceMotion: value),
+                                );
+                              });
+                              if (value) {
+                                _haloCtrl.stop();
+                              } else if (!_haloCtrl.isAnimating) {
+                                _haloCtrl.repeat();
+                              }
+                              _persistDraft();
+                            },
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    _glassField(
+                      child: FutureBuilder<List<Sticker>>(
+                        future: StickerService().loadStickers(),
+                        builder: (context, snap) {
+                          final list = snap.data ?? const <Sticker>[];
+                          _stickers = list;
+                          if (list.isEmpty) {
+                            return const Padding(
+                              padding: EdgeInsets.all(12),
+                              child: Text('Nu există autocolante disponibile. Adăugați PNG-uri în dosarul cu materiale/autocolante.'),
+                            );
+                          }
+                          return Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Row(
+                                children: const [
+                                  Icon(Icons.emoji_emotions_outlined, size: 18),
+                                  SizedBox(width: 8),
+                                  Text('Sticker'),
+                                ],
+                              ),
+                              const SizedBox(height: 12),
+                              Wrap(
+                                spacing: 12,
+                                runSpacing: 12,
+                                children: [
+                                  for (final sticker in list)
+                                    GestureDetector(
+                                      onTap: () async {
+                                        final asset = sticker.asset ?? sticker.url;
+                                        setState(() => _data = _data.copyWith(avatarSticker: asset));
+                                        await _persistDraft();
+                                      },
+                                      child: Container(
+                                        padding: const EdgeInsets.all(8),
+                                        decoration: BoxDecoration(
+                                          color: Colors.white.withOpacity(0.08),
+                                          borderRadius: BorderRadius.circular(16),
+                                          border: Border.all(
+                                            color: (_data.avatarSticker == (sticker.asset ?? sticker.url))
+                                                ? theme.colorScheme.primary
+                                                : Colors.white24,
+                                            width: 1.5,
+                                          ),
+                                        ),
+                                        child: SizedBox(
+                                          width: 64,
+                                          height: 64,
+                                          child: sticker.asset != null
+                                              ? Image.asset('assets/stickers/${sticker.asset!}', fit: BoxFit.contain)
+                                              : Image.network(sticker.url!, fit: BoxFit.contain),
+                                        ),
+                                      ),
+                                    ),
+                                  GestureDetector(
+                                    onTap: () async {
+                                      setState(() => _data = _data.copyWith(avatarSticker: null));
+                                      await _persistDraft();
+                                    },
+                                    child: Container(
+                                      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                                      decoration: BoxDecoration(
+                                        color: Colors.white.withOpacity(0.08),
+                                        borderRadius: BorderRadius.circular(16),
+                                        border: Border.all(color: Colors.white24, width: 1.5),
+                                      ),
+                                      child: const Icon(Icons.close, size: 18),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text('Social media', style: theme.textTheme.titleMedium),
+                    ),
+                    const SizedBox(height: 12),
+                    Wrap(
+                      spacing: 18,
+                      runSpacing: 12,
+                      alignment: WrapAlignment.center,
+                      children: [
+                        _socialButton('facebook', FontAwesomeIcons.facebookF, _data.social.facebook, 'Facebook', 'profile_facebook'),
+                        _socialButton('instagram', FontAwesomeIcons.instagram, _data.social.instagram, 'Instagram', 'profile_instagram'),
+                        _socialButton('tiktok', FontAwesomeIcons.tiktok, _data.social.tiktok, 'TikTok', 'profile_tiktok'),
+                        _socialButton('youtube', FontAwesomeIcons.youtube, _data.social.youtube, 'YouTube', 'profile_youtube'),
+                      ],
+                    ),
+                    const SizedBox(height: 80),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          bottomNavigationBar: SafeArea(
+            top: false,
+            child: AnimatedSlide(
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeOut,
+              offset: (_dirty && _data.isAuthenticated) ? Offset.zero : const Offset(0, 1),
+              child: AnimatedOpacity(
+                duration: const Duration(milliseconds: 200),
+                opacity: (_dirty && _data.isAuthenticated) ? 1 : 0,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                  child: Material(
+                    elevation: 6,
+                    borderRadius: BorderRadius.circular(16),
+                    color: theme.colorScheme.surface,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                      child: Row(
+                        children: [
+                          const Icon(Icons.info_outline, size: 18),
+                          const SizedBox(width: 8),
+                          const Expanded(child: Text('Ai modificări nesalvate.')),
+                          TextButton(
+                            onPressed: _revertLocal,
+                            child: const Text('Renunta'),
+                          ),
+                          const SizedBox(width: 4),
+                          ElevatedButton.icon(
+                            onPressed: _saving ? null : () => _saveProfileToServer(),
+                            icon: const Icon(Icons.save),
+                            label: const Text('Salveaza'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<bool> _onBackPressed() async {
+    if (!_dirty) return true;
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Modificări nesalvate'),
+        content: const Text('Vrei să părăsești pagina fără să salvezi?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Rămâi')),
+          TextButton(onPressed: () => Navigator.pop(context, true), child: const Text('Părăsește')),
+        ],
+      ),
+    );
+    return result ?? false;
+  }
+
+Widget _buildHeroSection(ThemeData theme, bool isSmall, double avatarRadius, String name) {
+  const double _ = 32;
+  final double heroHeight = isSmall ? 220.0 : 270.0;
+  final status = _data.status;
+  final bannerImage = _currentBannerImage();
+  final accent = _data.preferences.accentColor;
+  final double bubbleTouchGap = isSmall ? 6 : 8; 
+  final double bubbleR = avatarRadius + bubbleTouchGap;
+
+    return SizedBox(
+    height: heroHeight + avatarRadius + (isSmall ? 92 : 104),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            height: heroHeight,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(32),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.24),
+                    blurRadius: 28,
+                    offset: const Offset(0, 20),
+                  ),
+                ],
+              ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(32),
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    if (bannerImage != null)
+                      Image(image: bannerImage, fit: BoxFit.cover)
+                    else
+                      _buildBannerPlaceholder(theme, accent, isSmall),
+                    Positioned.fill(
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            colors: [
+                              Colors.black.withOpacity(0.35),
+                              Colors.black.withOpacity(0.18),
+                              Colors.black.withOpacity(0.55),
+                            ],
+                            begin: Alignment.topCenter,
+                            end: Alignment.bottomCenter,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            top: 20,
+            right: 20,
+            child: _floatingGlassButton(
+              icon: Icons.wallpaper_outlined,
+              label: I18n.t(context, 'edit_banner'),
+              onTap: _showBannerOptions,
+            ),
+          ),
+          Positioned(
+            left: isSmall ? 28 : 44,
+            bottom: avatarRadius + (isSmall ? 70 : 84),
+            right: isSmall ? 140 : 220,
+            child: _heroTextBlock(theme, name, isSmall),
+          ),
+           Positioned(
+              bottom: isSmall ? 60 : 88,
+              left: 0,
+              right: 0,
+              child: _buildAvatarCluster(avatarRadius, name),
+            ),
+
+          
+          Positioned.fill(
+              child: Align(
+                alignment: Alignment.center,
+                child: Transform.translate(
+                  offset: Offset(bubbleR * 1.10, -bubbleR * 0.20),
+                  child: status.isActive
+                      ? NoteOverlay(
+                          text: status.text ?? '',
+                          textColor: status.textColor,
+                          bgColor: status.backgroundColor,
+                          maxWidth: isSmall ? 180 : 240,
+                          onEdit: _editStatusNote,
+                          emoji: status.emoji,
+                          onPickEmoji: _pickEmoji,
+                        )
+                      : _statusPlaceholderChip(theme),))
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBannerPlaceholder(ThemeData theme, Color accent, bool isSmall) {
+    return Container(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            accent.withOpacity(0.65),
+            theme.colorScheme.primary.withOpacity(0.45),
+            theme.colorScheme.surfaceVariant.withOpacity(0.5),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+      ),
+      child: Stack(
+        children: [
+          Align(
+            alignment: Alignment.bottomLeft,
+            child: Padding(
+              padding: EdgeInsets.all(isSmall ? 18 : 28),
+              child: Text(
+                I18n.t(context, 'no_banner'),
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: Colors.white70,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+          Align(
+            alignment: Alignment.centerRight,
+            child: Icon(
+              Icons.wallpaper_outlined,
+              size: isSmall ? 88 : 120,
+              color: Colors.white.withOpacity(0.28),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _floatingGlassButton({required IconData icon, required String label, required VoidCallback onTap}) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(26),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+        child: Material(
+          color: Colors.white.withOpacity(0.18),
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(26),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(icon, size: 18, color: Colors.white),
+                  const SizedBox(width: 8),
+                  Text(
+                    label,
+                    style: Theme.of(context).textTheme.labelLarge?.copyWith(color: Colors.white),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _heroTextBlock(ThemeData theme, String name, bool isSmall) {
+    final pronouns = _data.pronouns;
+    final location = _data.location;
+    final website = _data.websiteUrl;
+    final headline = theme.textTheme.headlineSmall?.copyWith(
+      color: Colors.white,
+      fontWeight: FontWeight.w700,
+      letterSpacing: 0.2,
+      shadows: [Shadow(color: Colors.black.withOpacity(0.55), blurRadius: 16)],
+    );
+    final secondary = theme.textTheme.titleMedium?.copyWith(
+      color: Colors.white70,
+      fontWeight: FontWeight.w500,
+      shadows: [Shadow(color: Colors.black.withOpacity(0.35), blurRadius: 10)],
+    );
+
+    final widgets = <Widget>[
+      Text(
+        name.isEmpty ? I18n.t(context, 'profile') : name,
+        style: headline,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+    ];
+
+    if (pronouns != null && pronouns.isNotEmpty) {
+      widgets.add(const SizedBox(height: 4));
+      widgets.add(Text(pronouns, style: secondary?.copyWith(fontSize: (secondary?.fontSize ?? 16) - 2)));
+    }
+    if (location != null && location.isNotEmpty) {
+      widgets.add(const SizedBox(height: 4));
+      widgets.add(Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.location_on, size: 16, color: Colors.white70),
+          const SizedBox(width: 4),
+          Flexible(
+            child: Text(
+              location,
+              style: secondary,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ));
+    }
+    if (website != null && website.isNotEmpty) {
+      widgets.add(const SizedBox(height: 4));
+      widgets.add(GestureDetector(
+        onTap: () => _openLink(website),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.link, size: 16, color: Colors.white70),
+            const SizedBox(width: 4),
+            Flexible(
+              child: Text(
+                website,
+                style: secondary?.copyWith(decoration: TextDecoration.underline),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
+      ));
+    }
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxWidth: isSmall ? 220 : 320),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: widgets,
+      ),
+    );
+  }
+
+  Widget _statusPlaceholderChip(ThemeData theme) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(24),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+        child: Material(
+          color: Colors.white.withOpacity(0.18),
+          child: InkWell(
+            onTap: _editStatusNote,
+            borderRadius: BorderRadius.circular(24),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 10),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.auto_awesome, color: Colors.white, size: 18),
+                  const SizedBox(width: 8),
+                  Text(
+                    I18n.t(context, 'add_status'),
+                    style: theme.textTheme.labelLarge?.copyWith(color: Colors.white),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAvatarCluster(double avatarRadius, String name) {
+    final frame = _frameTempPreview ?? _data.avatarFrame;
+    final image = _currentAvatarImage();
+    final stickerAsset = _data.avatarSticker;
+    final stickerImage = (stickerAsset == null || stickerAsset.isEmpty)
+        ? null
+        : (stickerAsset.startsWith('http')
+            ? NetworkImage(stickerAsset)
+            : AssetImage('assets/stickers/$stickerAsset') as ImageProvider);
+    final reduceMotion = _data.preferences.reduceMotion;
+    final size = avatarRadius * 2 + 24;
+
+    return GestureDetector(
+      onTap: _showImageOptions,
+      onDoubleTap: _randomizeFrame,
+      onLongPress: _openAvatarViewer,
+      onHorizontalDragEnd: (details) {
+        final velocity = details.primaryVelocity ?? 0;
+        if (velocity.abs() < 80) return;
+        _cycleFrame(velocity < 0 ? 1 : -1);
+      },
+      child: SizedBox(
+  width: (size as num).toDouble(),   // vagy: final double size = ...; feljebb
+  height: (size as num).toDouble(),
+  child: Stack(
+    clipBehavior: Clip.none,
+    alignment: Alignment.center,
+    children: [
+      Positioned.fill(
+        child: RepaintBoundary(
+          child: AnimatedBuilder(
+            animation: _haloCtrl,
+            builder: (context, _) {
+              // legyen explicit double
+              final double rotation =
+                  reduceMotion ? 0.0 : _haloCtrl.value * 2 * math.pi;
+
+              return CustomPaint(
+                painter: _HaloPainter(
+                  rotation: rotation, // most már double
+                  colors: _colorsForFrame(frame),
+                  strength: (_data.preferences.haloStrength as num).toDouble(),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+            if (_data.status.isActive)
+              Positioned.fill(
+                child: IgnorePointer(
+                  ignoring: true,
+                  child: RepaintBoundary(
+                    child: CustomPaint(
+                      painter: _CountdownRingPainter(
+                        progress: _statusProgress,
+                        trackColor: Colors.white.withOpacity(0.16),
+                        glowColor: Theme.of(context).colorScheme.primary,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            Hero(
+              tag: 'profile_avatar_hero',
+              child: FramedAvatar(
+                image: image,
+                name: name,
+                radius: avatarRadius,
+                frameStyle: frame,
+                stickerImage: stickerImage,
+              ),
+            ),
+            Positioned(
+              bottom: -4,
+              right: -4,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primary,
+                  shape: BoxShape.circle,
+                  border: Border.all(color: Colors.white, width: 2),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Theme.of(context).colorScheme.primary.withOpacity(0.45),
+                      blurRadius: 10,
+                      offset: const Offset(0, 4),
+                    ),
+                  ],
+                ),
+                padding: const EdgeInsets.all(6),
+                child: const Icon(Icons.camera_alt, color: Colors.white, size: 18),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  ImageProvider? _currentBannerImage() {
+    final banner = _data.banner;
+    if (banner.url != null && banner.url!.isNotEmpty && banner.bytes == null && (banner.localPath == null || banner.localPath!.isEmpty)) {
+      return NetworkImage(UiUtils.normalizeUploadUrl(banner.url!));
+    }
+    if (kIsWeb) {
+      if (banner.bytes != null && banner.bytes!.isNotEmpty) {
+        return MemoryImage(banner.bytes!);
+      }
+    } else {
+      if (banner.localPath != null && banner.localPath!.isNotEmpty) {
+        final file = File(banner.localPath!);
+        if (file.existsSync()) {
+          return FileImage(file);
+        }
+      }
+    }
+    return null;
+  }
+
+  Widget _glassField({required Widget child}) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(20),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+        child: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [
+                Colors.white.withOpacity(0.18),
+                Colors.white.withOpacity(0.05),
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(color: Colors.white.withOpacity(0.18)),
+            boxShadow: [
+              BoxShadow(color: Colors.black.withOpacity(0.2), blurRadius: 16, offset: const Offset(0, 8)),
+            ],
+          ),
+          padding: const EdgeInsets.all(16),
+          child: child,
+        ),
+      ),
+    );
+  }
+
+  ImageProvider? _currentAvatarImage() {
+    final avatar = _data.avatar;
+    if (avatar.url != null && avatar.url!.isNotEmpty && avatar.bytes == null && (avatar.localPath == null || avatar.localPath!.isEmpty)) {
+      return NetworkImage(UiUtils.normalizeUploadUrl(avatar.url!));
+    }
+    if (kIsWeb) {
+      if (avatar.bytes != null && avatar.bytes!.isNotEmpty) {
+        return MemoryImage(avatar.bytes!);
+      }
+    } else {
+      if (avatar.localPath != null && avatar.localPath!.isNotEmpty && File(avatar.localPath!).existsSync()) {
+        return FileImage(File(avatar.localPath!));
+      }
+    }
+    return null;
+  }
+
+  List<Color> _colorsForFrame(String style) {
+    switch (style) {
+      case 'gradient-sunset':
+        return const [Color(0xFFFF512F), Color(0xFFF09819)];
+      case 'gradient-ocean':
+        return const [Color(0xFF36D1DC), Color(0xFF5B86E5)];
+      case 'gradient-forest':
+        return const [Color(0xFF11998E), Color(0xFF38EF7D)];
+      case 'gradient-violet':
+        return const [Color(0xFF8E2DE2), Color(0xFF4A00E0)];
+      case 'gradient-royal':
+        return const [Color(0xFF141E30), Color(0xFF243B55)];
+      case 'gradient-aurora':
+        return const [Color(0xFF00C9FF), Color(0xFF92FE9D)];
+      case 'gradient-plasma':
+        return const [Color(0xFF12C2E9), Color(0xFFC471ED), Color(0xFFF64F59)];
+      case 'gradient-gold':
+        return const [Color(0xFFFFD700), Color(0xFFFFB700)];
+      case 'gradient-silver':
+        return const [Color(0xFFBCC6CC), Color(0xFFE5E4E2)];
+      case 'rainbow':
+        return const [Colors.red, Colors.orange, Colors.yellow, Colors.green, Colors.blue, Colors.indigo, Colors.purple];
+      default:
+        return [
+          Theme.of(context).colorScheme.primary,
+          Theme.of(context).colorScheme.primary.withOpacity(0.55),
+        ];
+    }
+  }
+
+  void _openAvatarViewer() {
+    final image = _currentAvatarImage();
+    if (image == null) return;
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => _AvatarViewer(image: image)),
+    );
+  }
+}

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,0 +1,407 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart' show kIsWeb, defaultTargetPlatform, TargetPlatform;
+import 'package:http/http.dart' as http;
+
+class ApiException implements Exception {
+  final String message;
+  final int? status;
+  ApiException(this.message, {this.status});
+  @override
+  String toString() => 'ApiException(${status ?? ''}): $message';
+}
+
+class ApiService {
+  // IMPORTANT:
+  // - On Android emulator use http://10.0.2.2
+  // - On iOS simulator/desktop/web use http://127.0.0.1
+  // - On a physical device use your PC's LAN IP (e.g. http://192.168.x.x)
+  // You can override via: --dart-define=API_BASE_URL=http://192.168.x.x/bot/server/public
+  static final String baseUrl = _detectBaseUrl();
+
+  static get uploadBaseUrl => null;
+
+  static String _detectBaseUrl() {
+    const fromEnv = String.fromEnvironment('API_BASE_URL', defaultValue: '');
+    if (fromEnv.isNotEmpty) return fromEnv;
+    if (kIsWeb) return 'http://127.0.0.1/bot/server/public';
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      return 'http://10.0.2.2/bot/server/public';
+    }
+    return 'http://127.0.0.1/bot/server/public';
+  }
+
+  Uri _url(String path) => Uri.parse('$baseUrl$path');
+
+  Future<(String token, Map<String, dynamic> user)> login({required String username, required String password}) async {
+    final res = await http.post(
+      _url('/api/login.php'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'username': username, 'password': password}),
+    );
+    final data = _decode(res);
+    // Be tolerant to slightly different shapes or extra output
+    final token = (data['token']) ?? (data['data'] is Map ? (data['data']['token']) : null);
+    final user = (data['user']) ?? (data['data'] is Map ? (data['data']['user']) : null);
+    if (res.statusCode >= 200 && res.statusCode < 300 && token != null) {
+      final userMap = (user is Map) ? Map<String, dynamic>.from(user) : <String, dynamic>{};
+      return (token as String, userMap);
+    }
+    final msg = data['error']?.toString() ?? (data['raw']?.toString()) ?? 'Login failed';
+    throw ApiException(msg, status: res.statusCode);
+  }
+
+  Future<Map<String, dynamic>> getProfile(String token) async {
+    final res = await http.get(
+      _url('/api/profile.php'),
+      headers: {'Authorization': 'Bearer $token'},
+    );
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['profile'] != null) {
+      return Map<String, dynamic>.from(data['profile'] as Map);
+    }
+    throw ApiException(data['error']?.toString() ?? 'Cannot load profile', status: res.statusCode);
+  }
+
+  Future<Map<String, dynamic>> updateProfile(String token, Map<String, dynamic> payload) async {
+    final res = await http.post(
+      _url('/api/profile.php'),
+      headers: {'Authorization': 'Bearer $token', 'Content-Type': 'application/json'},
+      body: jsonEncode(payload),
+    );
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['profile'] != null) {
+      return Map<String, dynamic>.from(data['profile'] as Map);
+    }
+    throw ApiException(data['error']?.toString() ?? 'Cannot update profile', status: res.statusCode);
+  }
+
+  // Posts
+  Future<List<Map<String, dynamic>>> getPosts({int limit = 20, int offset = 0}) async {
+    final uri = _url('/api/posts.php').replace(queryParameters: {
+      'limit': '$limit',
+      'offset': '$offset',
+    });
+    final res = await http.get(uri);
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+      final list = (data['posts'] as List?) ?? const [];
+      return list.map((e) => Map<String, dynamic>.from(e as Map)).toList();
+    }
+    throw ApiException(data['error']?.toString() ?? 'Cannot load posts', status: res.statusCode);
+  }
+
+  Future<Map<String, dynamic>> createPost(String token, String content, {String visibility = 'public', String? bgColor, String? textColor, String? emoji}) async {
+    final res = await http.post(
+      _url('/api/posts.php'),
+      headers: {'Authorization': 'Bearer $token', 'Content-Type': 'application/json'},
+      body: jsonEncode({'content': content, 'visibility': visibility, 'bg_color': bgColor, 'text_color': textColor, 'feeling_emoji': emoji}),
+    );
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['post'] != null) {
+      return Map<String, dynamic>.from(data['post'] as Map);
+    }
+    throw ApiException(data['error']?.toString() ?? 'Cannot create post', status: res.statusCode);
+  }
+
+  Future<Map<String, dynamic>> createPostWithImage(String token, String content, String imagePath,
+      {String? filename, String? contentType, String visibility = 'public', String? bgColor, String? textColor, String? emoji}) async {
+    final req = http.MultipartRequest('POST', _url('/api/posts.php'))
+      ..headers['Authorization'] = 'Bearer $token'
+      ..fields['content'] = content
+      ..fields['visibility'] = visibility
+      ..fields['bg_color'] = bgColor ?? ''
+      ..fields['text_color'] = textColor ?? ''
+      ..fields['feeling_emoji'] = emoji ?? ''
+      ..files.add(await http.MultipartFile.fromPath('image', imagePath, filename: filename, contentType: _mediaType(contentType)));
+    final res = await http.Response.fromStream(await req.send());
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['post'] != null) {
+      return Map<String, dynamic>.from(data['post'] as Map);
+    }
+    throw ApiException(data['error']?.toString() ?? 'Cannot create post', status: res.statusCode);
+  }
+
+  Future<void> deletePost(String token, int id) async {
+    final uri = _url('/api/posts.php').replace(queryParameters: {'id': '$id'});
+    final res = await http.delete(uri, headers: {'Authorization': 'Bearer $token'});
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      final data = _decode(res);
+      throw ApiException(data['error']?.toString() ?? 'Cannot delete post', status: res.statusCode);
+    }
+  }
+
+  Future<Map<String, dynamic>> updatePost(
+    String token,
+    int id,
+    {
+      required String content,
+      String visibility = 'public',
+      String? bgColor,
+      String? textColor,
+      String? emoji,
+    }
+  ) async {
+    final uri = _url('/api/posts.php').replace(queryParameters: {'id': '$id'});
+    final res = await http.patch(
+      uri,
+      headers: {'Authorization': 'Bearer $token', 'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'content': content,
+        'visibility': visibility,
+        'bg_color': bgColor,
+        'text_color': textColor,
+        'feeling_emoji': emoji,
+      }),
+    );
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['post'] != null) {
+      return Map<String, dynamic>.from(data['post'] as Map);
+    }
+    throw ApiException(data['error']?.toString() ?? 'Cannot update post', status: res.statusCode);
+  }
+
+  // Web/bytes-friendly variant for image uploads
+  Future<Map<String, dynamic>> createPostWithImageBytes(
+    String token,
+    String content,
+    List<int> bytes, {
+    String filename = 'image.jpg',
+    String? contentType,
+    String visibility = 'public',
+    String? bgColor,
+    String? textColor,
+    String? emoji,
+  }) async {
+    final req = http.MultipartRequest('POST', _url('/api/posts.php'))
+      ..headers['Authorization'] = 'Bearer $token'
+      ..fields['content'] = content
+      ..fields['visibility'] = visibility
+      ..fields['bg_color'] = bgColor ?? ''
+      ..fields['text_color'] = textColor ?? ''
+      ..fields['feeling_emoji'] = emoji ?? ''
+      ..files.add(http.MultipartFile.fromBytes('image', bytes, filename: filename, contentType: _mediaType(contentType)));
+    final res = await http.Response.fromStream(await req.send());
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['post'] != null) {
+      return Map<String, dynamic>.from(data['post'] as Map);
+    }
+    throw ApiException(data['error']?.toString() ?? 'Cannot create post', status: res.statusCode);
+  }
+
+  
+
+  Future<Map<String, dynamic>> reactToPost(String token, int postId, {String type = 'like'}) async {
+    final res = await http.post(
+      _url('/api/reactions.php'),
+      headers: {'Authorization': 'Bearer $token', 'Content-Type': 'application/json'},
+      body: jsonEncode({'post_id': postId, 'type': type}),
+    );
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300) return data;
+    throw ApiException(data['error']?.toString() ?? 'Reaction failed', status: res.statusCode);
+  }
+
+  Future<Map<String, dynamic>> getReactions(int postId, {String? token}) async {
+    final uri = _url('/api/reactions.php').replace(queryParameters: {'post_id': '$postId'});
+    final headers = <String, String>{};
+    if (token != null && token.isNotEmpty) {
+      headers['Authorization'] = 'Bearer $token';
+    }
+    final res = await http.get(uri, headers: headers);
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+      return Map<String, dynamic>.from(data);
+    }
+    throw ApiException(data['error']?.toString() ?? 'Cannot load reactions', status: res.statusCode);
+  }
+
+  Future<List<Map<String, dynamic>>> getComments(int postId) async {
+    final uri = _url('/api/comments.php').replace(queryParameters: {'post_id': '$postId'});
+    final res = await http.get(uri);
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+      final list = (data['comments'] as List?) ?? const [];
+      return list.map((e) => Map<String, dynamic>.from(e as Map)).toList();
+    }
+    throw ApiException(data['error']?.toString() ?? 'Cannot load comments', status: res.statusCode);
+  }
+
+  Future<Map<String, dynamic>> addComment(String token, int postId, String content, {int? parentId}) async {
+    final res = await http.post(
+      _url('/api/comments.php'),
+      headers: {'Authorization': 'Bearer $token', 'Content-Type': 'application/json'},
+      body: jsonEncode({'post_id': postId, 'content': content, if (parentId != null) 'parent_id': parentId}),
+    );
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300) return Map<String, dynamic>.from(data['comment'] as Map);
+    throw ApiException(data['error']?.toString() ?? 'Cannot add comment', status: res.statusCode);
+  }
+
+  Future<void> deleteComment(String token, int commentId) async {
+    final uri = _url('/api/comments.php').replace(queryParameters: {'id': '$commentId'});
+    final res = await http.delete(uri, headers: {'Authorization': 'Bearer $token'});
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      final data = _decode(res);
+      throw ApiException(data['error']?.toString() ?? 'Cannot delete comment', status: res.statusCode);
+    }
+  }
+
+  Future<Map<String, dynamic>> reactToComment(String token, int commentId, {String type = 'like'}) async {
+    final res = await http.post(
+      _url('/api/comment_reactions.php'),
+      headers: {'Authorization': 'Bearer $token', 'Content-Type': 'application/json'},
+      body: jsonEncode({'comment_id': commentId, 'type': type}),
+    );
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300) return data;
+    throw ApiException(data['error']?.toString() ?? 'Reaction failed', status: res.statusCode);
+  }
+
+  Future<Map<String, dynamic>> getCommentReactions(int commentId, {String? token}) async {
+    final uri = _url('/api/comment_reactions.php').replace(queryParameters: {'comment_id': '$commentId'});
+    final headers = <String, String>{};
+    if (token != null) headers['Authorization'] = 'Bearer $token';
+    final res = await http.get(uri, headers: headers);
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300) return Map<String, dynamic>.from(data);
+    throw ApiException(data['error']?.toString() ?? 'Cannot load comment reactions', status: res.statusCode);
+  }
+
+  Map<String, dynamic> _decode(http.Response res) {
+    try {
+      final body = jsonDecode(res.body);
+      return (body is Map<String, dynamic>) ? body : <String, dynamic>{'data': body};
+    } catch (_) {
+      // Try to salvage JSON from noisy responses (e.g., warnings before JSON)
+      final text = res.body;
+      final start = text.indexOf('{');
+      final end = text.lastIndexOf('}');
+      if (start != -1 && end != -1 && end > start) {
+        final slice = text.substring(start, end + 1);
+        try {
+          final body = jsonDecode(slice);
+          return (body is Map<String, dynamic>) ? body : <String, dynamic>{'data': body};
+        } catch (_) {}
+      }
+      return <String, dynamic>{'error': 'Invalid JSON', 'raw': res.body};
+    }
+  }
+
+  Future<String> uploadAvatarBytes(String token, List<int> bytes, {String filename = 'avatar.jpg', String contentType = 'image/jpeg'}) async {
+    final req = http.MultipartRequest('POST', _url('/api/avatar.php'))
+      ..headers['Authorization'] = 'Bearer $token'
+      ..files.add(http.MultipartFile.fromBytes('file', bytes, filename: filename, contentType: _mediaType(contentType)));
+    final res = await http.Response.fromStream(await req.send());
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['avatar_url'] != null) {
+      return data['avatar_url'] as String;
+    }
+    throw ApiException(data['error']?.toString() ?? 'Upload failed', status: res.statusCode);
+  }
+
+  Future<String> uploadAvatarPath(String token, String path, {String? filename, String? contentType}) async {
+    final req = http.MultipartRequest('POST', _url('/api/avatar.php'))
+      ..headers['Authorization'] = 'Bearer $token'
+      ..files.add(await http.MultipartFile.fromPath('file', path, filename: filename, contentType: _mediaType(contentType)));
+    final res = await http.Response.fromStream(await req.send());
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['avatar_url'] != null) {
+      return data['avatar_url'] as String;
+    }
+    throw ApiException(data['error']?.toString() ?? 'Upload failed', status: res.statusCode);
+  }
+
+  Future<void> deleteAvatar(String token) async {
+    final res = await http.delete(_url('/api/avatar.php'), headers: {'Authorization': 'Bearer $token'});
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      final data = _decode(res);
+      throw ApiException(data['error']?.toString() ?? 'Delete failed', status: res.statusCode);
+    }
+  }
+
+  // Banner upload/delete
+  Future<String> uploadBannerBytes(String token, List<int> bytes, {String filename = 'banner.jpg', String contentType = 'image/jpeg'}) async {
+    final req = http.MultipartRequest('POST', _url('/api/banner.php'))
+      ..headers['Authorization'] = 'Bearer $token'
+      ..files.add(http.MultipartFile.fromBytes('file', bytes, filename: filename, contentType: _mediaType(contentType)));
+    final res = await http.Response.fromStream(await req.send());
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['banner_url'] != null) {
+      return data['banner_url'] as String;
+    }
+    throw ApiException(data['error']?.toString() ?? 'Upload failed', status: res.statusCode);
+  }
+
+  Future<String> uploadBannerPath(String token, String path, {String? filename, String? contentType}) async {
+    final req = http.MultipartRequest('POST', _url('/api/banner.php'))
+      ..headers['Authorization'] = 'Bearer $token'
+      ..files.add(await http.MultipartFile.fromPath('file', path, filename: filename, contentType: _mediaType(contentType)));
+    final res = await http.Response.fromStream(await req.send());
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['banner_url'] != null) {
+      return data['banner_url'] as String;
+    }
+    throw ApiException(data['error']?.toString() ?? 'Upload failed', status: res.statusCode);
+  }
+
+  Future<void> deleteBanner(String token) async {
+    final res = await http.delete(_url('/api/banner.php'), headers: {'Authorization': 'Bearer $token'});
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      final data = _decode(res);
+      throw ApiException(data['error']?.toString() ?? 'Delete failed', status: res.statusCode);
+    }
+  }
+
+  // Helper to build MediaType without importing http_parser directly
+  dynamic _mediaType(String? contentType) {
+    if (contentType == null) return null;
+    try {
+      final parts = contentType.split('/');
+      if (parts.length == 2) {
+        // http.MultipartFile expects a MediaType from package:http_parser, but
+        // it accepts a dynamic. Avoid hard dep; null is also acceptable.
+        // However, when null, http will infer from filename. We'll return null if parsing fails.
+        // Leaving as null keeps compatibility.
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  Future<Map<String, dynamic>> updateComment(String token, int commentId, String text) async {
+    final res = await http.patch(
+      _url('/api/comments.php'),
+      headers: {'Authorization': 'Bearer $token', 'Content-Type': 'application/json'},
+      body: jsonEncode({'id': commentId, 'content': text}),
+    );
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['comment'] is Map) {
+      return Map<String, dynamic>.from(data['comment'] as Map);
+    }
+    throw ApiException(data['error']?.toString() ?? 'Cannot update comment', status: res.statusCode);
+  }
+
+  Future<String> uploadCommentMedia(String token, String path, {String? filename, String? contentType}) async {
+    final req = http.MultipartRequest('POST', _url('/api/comment_media.php'))
+      ..headers['Authorization'] = 'Bearer $token'
+      ..files.add(await http.MultipartFile.fromPath('file', path, filename: filename, contentType: _mediaType(contentType)));
+    final res = await http.Response.fromStream(await req.send());
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['url'] != null) {
+      return data['url'] as String;
+    }
+    throw ApiException(data['error']?.toString() ?? 'Upload failed', status: res.statusCode);
+  }
+
+  Future<String> uploadCommentMediaBytes(String token, List<int> bytes,
+      {String filename = 'attachment.jpg', String? contentType}) async {
+    final req = http.MultipartRequest('POST', _url('/api/comment_media.php'))
+      ..headers['Authorization'] = 'Bearer $token'
+      ..files.add(http.MultipartFile.fromBytes('file', bytes, filename: filename, contentType: _mediaType(contentType)));
+    final res = await http.Response.fromStream(await req.send());
+    final data = _decode(res);
+    if (res.statusCode >= 200 && res.statusCode < 300 && data['url'] != null) {
+      return data['url'] as String;
+    }
+    throw ApiException(data['error']?.toString() ?? 'Upload failed', status: res.statusCode);
+  }
+}

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -18,7 +18,11 @@ class ApiService {
   // You can override via: --dart-define=API_BASE_URL=http://192.168.x.x/bot/server/public
   static final String baseUrl = _detectBaseUrl();
 
-  static get uploadBaseUrl => null;
+  static String get uploadBaseUrl {
+    final root = baseUrl;
+    if (root.endsWith('/public')) return root;
+    return '$root/public';
+  }
 
   static String _detectBaseUrl() {
     const fromEnv = String.fromEnvironment('API_BASE_URL', defaultValue: '');

--- a/lib/utils/i18n.dart
+++ b/lib/utils/i18n.dart
@@ -1,0 +1,285 @@
+import 'package:flutter/widgets.dart';
+import '../services/settings_service.dart';
+
+class I18n {
+  // Romanize Romanian (strip diacritics) per requirement
+  static String _romanizeRo(String input) {
+    return input
+        .replaceAll('ș', 's')
+        .replaceAll('ş', 's')
+        .replaceAll('ț', 't')
+        .replaceAll('ţ', 't')
+        .replaceAll('ă', 'a')
+        .replaceAll('â', 'a')
+        .replaceAll('î', 'i')
+        .replaceAll('Ș', 'S')
+        .replaceAll('Ş', 'S')
+        .replaceAll('Ț', 'T')
+        .replaceAll('Ţ', 'T')
+        .replaceAll('Ă', 'A')
+        .replaceAll('Â', 'A')
+        .replaceAll('Î', 'I');
+  }
+
+  static const _k = <String, Map<String, String>>{
+    // Core
+    'app_title': {'hu': 'Alkalmazás', 'en': 'Application', 'ro': 'Aplicatie'},
+    'home': {'hu': 'Kezdőlap', 'en': 'Home', 'ro': 'Acasa'},
+    'profile': {'hu': 'Profil', 'en': 'Profile', 'ro': 'Profil'},
+    'settings': {'hu': 'Beállítások', 'en': 'Settings', 'ro': 'Setari'},
+    'help': {'hu': 'Súgó', 'en': 'Help', 'ro': 'Ajutor'},
+    'create': {'hu': 'Létrehozás', 'en': 'Create', 'ro': 'Creeaza'},
+    'search': {'hu': 'Keresés', 'en': 'Search', 'ro': 'Cauta'},
+    'messages': {'hu': 'Üzenetek', 'en': 'Messages', 'ro': 'Mesaje'},
+    'new_posts': {'hu': 'Új bejegyzések érhetők el', 'en': 'New posts available', 'ro': 'Sunt postari noi disponibile'},
+    'reload': {'hu': 'Frissít', 'en': 'Reload', 'ro': 'Reincarca'},
+    'saved': {'hu': 'Mentve', 'en': 'Saved', 'ro': 'Salvat'},
+    'posted': {'hu': 'Közzétéve', 'en': 'Posted', 'ro': 'Postat'},
+    'error': {'hu': 'Hiba', 'en': 'Error', 'ro': 'Eroare'},
+    'help_placeholder': {
+      'hu': 'Itt hamarosan tippek és útmutatók lesznek.',
+      'en': 'Helpful tips are coming soon.',
+      'ro': 'Sfaturi utile vor fi disponibile in curand.'
+    },
+    'theme': {'hu': 'Téma', 'en': 'Theme', 'ro': 'Tema'},
+    'language': {'hu': 'Nyelv', 'en': 'Language', 'ro': 'Limba'},
+    'system': {'hu': 'Rendszer', 'en': 'System', 'ro': 'Sistem'},
+    'light': {'hu': 'Világos', 'en': 'Light', 'ro': 'Luminos'},
+    'dark': {'hu': 'Sötét', 'en': 'Dark', 'ro': 'Intunecat'},
+    'scheduled': {'hu': 'Ütemezett', 'en': 'Scheduled', 'ro': 'Programat'},
+    'appearance': {'hu': 'Megjelenés', 'en': 'Appearance', 'ro': 'Aspect'},
+    'appearance_hint': {
+      'hu': 'Hangold a felületet a hangulatodhoz – téma, színek, fényerő.',
+      'en': 'Fine-tune the interface with futuristic themes and colors.',
+      'ro': 'Personalizează interfața cu teme și culori futuriste.'
+    },
+    'settings_tagline': {
+      'hu': 'Állíts be mindent a 2025-ös vibe-hoz igazodva.',
+      'en': 'Tailor every pixel for a 2025-ready experience.',
+      'ro': 'Personalizează fiecare detaliu pentru o experiență 2025.'
+    },
+    'theme_mode': {'hu': 'Téma mód', 'en': 'Theme mode', 'ro': 'Mod temă'},
+    'dynamic_color': {'hu': 'Dinamikus színek', 'en': 'Dynamic colors', 'ro': 'Culori dinamice'},
+    'dynamic_color_hint': {
+      'hu': 'Automatikus Material You árnyalatok az eszköz háttérképe alapján.',
+      'en': 'Adopt Material You shades from your device wallpaper.',
+      'ro': 'Adoptă nuanțe Material You inspirate de tapetul dispozitivului.'
+    },
+    'true_black': {'hu': 'Valódi fekete mód', 'en': 'True black mode', 'ro': 'Mod negru absolut'},
+    'high_contrast': {'hu': 'Magas kontraszt', 'en': 'High contrast', 'ro': 'Contrast ridicat'},
+    'accent_color': {'hu': 'Kiemelő szín', 'en': 'Accent color', 'ro': 'Culoare accent'},
+    'accent_default': {'hu': 'Alapértelmezett', 'en': 'Default', 'ro': 'Implicit'},
+    'start_time': {'hu': 'Indulás', 'en': 'Start', 'ro': 'Start'},
+    'end_time': {'hu': 'Leállítás', 'en': 'End', 'ro': 'Final'},
+    'reading_experience': {'hu': 'Olvasási élmény', 'en': 'Reading experience', 'ro': 'Experiență de lectură'},
+    'reading_experience_hint': {
+      'hu': 'Betűméret, animációk és rezgések testreszabása.',
+      'en': 'Adjust typography, motion and tactile feedback.',
+      'ro': 'Ajustează tipografia, mișcarea și feedback-ul haptic.'
+    },
+    'text_scale': {'hu': 'Szövegméret', 'en': 'Text size', 'ro': 'Dimensiune text'},
+    'haptics': {'hu': 'Haptikus visszajelzés', 'en': 'Haptic feedback', 'ro': 'Feedback haptic'},
+    'language_hint': {
+      'hu': 'Válaszd ki az alkalmazás nyelvét. Rendszer = automatikus.',
+      'en': 'Choose the interface language. System = automatic.',
+      'ro': 'Alege limba interfeței. Sistem = automat.'
+    },
+    'advanced': {'hu': 'Haladó', 'en': 'Advanced', 'ro': 'Avansat'},
+    'advanced_hint': {
+      'hu': 'Exportálás, importálás és gyári alaphelyzet.',
+      'en': 'Export, import and reset settings.',
+      'ro': 'Exportă, importă și resetează setările.'
+    },
+    'export_settings': {'hu': 'Beállítások exportálása', 'en': 'Export settings', 'ro': 'Exportă setările'},
+    'export_settings_hint': {
+      'hu': 'Másold vágólapra JSON formátumban.',
+      'en': 'Copy everything as JSON to your clipboard.',
+      'ro': 'Copiază totul în format JSON în clipboard.'
+    },
+    'import_settings': {'hu': 'Beállítások importálása', 'en': 'Import settings', 'ro': 'Importă setările'},
+    'import_settings_hint': {
+      'hu': 'Illessz be korábban exportált JSON-t.',
+      'en': 'Paste JSON exported from another device.',
+      'ro': 'Inserează JSON exportat de pe alt dispozitiv.'
+    },
+    'paste_settings_hint': {
+      'hu': 'Illeszd be ide a JSON konfigurációt...',
+      'en': 'Paste the JSON configuration here...',
+      'ro': 'Lipește aici configurația JSON...'
+    },
+    'settings_copied': {'hu': 'Beállítások vágólapra másolva.', 'en': 'Settings copied to clipboard.', 'ro': 'Setările au fost copiate.'},
+    'import_success': {'hu': 'Importálás sikeres.', 'en': 'Import successful.', 'ro': 'Import reușit.'},
+    'import_failed': {'hu': 'Importálás sikertelen', 'en': 'Import failed', 'ro': 'Import eșuat'},
+    'reset': {'hu': 'Alaphelyzet', 'en': 'Reset', 'ro': 'Resetare'},
+    'reset_hint': {
+      'hu': 'Minden beállítás visszaáll az alap értékre.',
+      'en': 'Restore every preference to its default.',
+      'ro': 'Revino la valorile implicite pentru toate preferințele.'
+    },
+    'reset_confirm': {
+      'hu': 'Biztosan visszaállítod az összes beállítást?',
+      'en': 'Do you really want to reset all settings?',
+      'ro': 'Sigur dorești să resetezi toate setările?'
+    },
+    'reset_done': {'hu': 'Beállítások visszaállítva.', 'en': 'Settings restored.', 'ro': 'Setările au fost resetate.'},
+    // Common actions
+    'ok': {'hu': 'OK', 'en': 'OK', 'ro': 'OK'},
+    'cancel': {'hu': 'Mégse', 'en': 'Cancel', 'ro': 'Anuleaza'},
+    'close': {'hu': 'Bezárás', 'en': 'Close', 'ro': 'Inchide'},
+    'save': {'hu': 'Mentés', 'en': 'Save', 'ro': 'Salveaza'},
+    'discard': {'hu': 'Elvet', 'en': 'Discard', 'ro': 'Renunta'},
+    'delete': {'hu': 'Törlés', 'en': 'Delete', 'ro': 'Sterge'},
+    'open': {'hu': 'Megnyitás', 'en': 'Open', 'ro': 'Deschide'},
+    'edit': {'hu': 'Szerkesztés', 'en': 'Edit', 'ro': 'Editeaza'},
+    'copied': {'hu': 'Másolva', 'en': 'Copied', 'ro': 'Copiat'},
+    // Profile specific
+    'not_authenticated': {'hu': 'Nem vagy bejelentkezve.', 'en': 'You are not authenticated.', 'ro': 'Nu esti autentificat.'},
+    'profile_saved': {'hu': 'Profil mentve.', 'en': 'Profile saved.', 'ro': 'Profil salvat.'},
+    'save_failed': {'hu': 'Mentés sikertelen', 'en': 'Save failed', 'ro': 'Salvare esuata'},
+    'avatar_updated': {'hu': 'Avatar frissítve.', 'en': 'Avatar updated.', 'ro': 'Avatar actualizat.'},
+    'banner_updated': {'hu': 'Banner frissítve.', 'en': 'Banner updated.', 'ro': 'Banner actualizat.'},
+    'upload_error': {'hu': 'Feltöltési hiba', 'en': 'Upload error', 'ro': 'Eroare upload'},
+    'avatar_delete_failed': {'hu': 'Avatar törlése sikertelen', 'en': 'Avatar delete failed', 'ro': 'Stergere avatar esuata'},
+    'banner_delete_failed': {'hu': 'Banner törlése sikertelen', 'en': 'Banner delete failed', 'ro': 'Stergere banner esuata'},
+    'invalid_session': {'hu': 'Érvénytelen/lejárt munkamenet. Jelentkezz be újra.', 'en': 'Invalid/expired session. Please sign in again.', 'ro': 'Sesiune invalida/expirata. Te rugam sa te reconectezi.'},
+    'unsaved_changes': {'hu': 'Mentetlen módosítások', 'en': 'Unsaved changes', 'ro': 'Modificari nesalvate'},
+    'leave_without_saving': {'hu': 'Elhagyod az oldalt mentés nélkül?', 'en': 'Leave page without saving?', 'ro': 'Vrei sa parasesti pagina fara sa salvezi?'},
+    // Choosers
+    'pick_from_gallery': {'hu': 'Válassz a galériából', 'en': 'Choose from gallery', 'ro': 'Alege din galerie'},
+    'take_photo': {'hu': 'Készíts fotót', 'en': 'Take a photo', 'ro': 'Fa o poza'},
+    'delete_avatar': {'hu': 'Avatar törlése', 'en': 'Delete avatar', 'ro': 'Sterge avatarul'},
+    'zoom_avatar': {'hu': 'Nagyítás (pinch-to-zoom)', 'en': 'Zoom (pinch-to-zoom)', 'ro': 'Marire (pinch-to-zoom)'},
+    'image_load_error': {'hu': 'Hiba a kép betöltésekor', 'en': 'Error loading image', 'ro': 'Eroare la incarcare imagine'},
+    'pick_banner': {'hu': 'Válassz bannert', 'en': 'Choose banner', 'ro': 'Alege bannerul'},
+    'delete_banner': {'hu': 'Banner törlése', 'en': 'Delete banner', 'ro': 'Sterge bannerul'},
+    'banner_load_error': {'hu': 'Hiba a banner betöltésekor', 'en': 'Error loading banner', 'ro': 'Eroare la incarcare banner'},
+    'edit_banner': {'hu': 'Banner szerkesztése', 'en': 'Edit banner', 'ro': 'Editeaza bannerul'},
+    'no_banner': {'hu': 'Nincs beállított banner', 'en': 'No banner set', 'ro': 'Fara banner setat'},
+    // Settings bits
+    'stickers': {'hu': 'Matricák', 'en': 'Stickers', 'ro': 'Stickere'},
+    'choose_sticker': {'hu': 'Válassz matricát', 'en': 'Choose a sticker', 'ro': 'Alege un sticker'},
+    'remove': {'hu': 'Eltávolítás', 'en': 'Remove', 'ro': 'Sterge'},
+    'reduce_motion': {'hu': 'Animációk csökkentése (minimális effektusok)', 'en': 'Reduce motion (minimal effects)', 'ro': 'Reduce motion (efecte minime)'},
+    'halo_power': {'hu': 'Halo ereje', 'en': 'Halo power', 'ro': 'Puterea haloului'},
+    'no_stickers': {'hu': 'Nincs elérhető matrica. Adj hozzá PNG-ket az assets/stickers mappába.', 'en': 'No stickers available. Add PNGs to assets/stickers.', 'ro': 'Nu exista stickere disponibile. Adauga PNG-uri in assets/stickers.'},
+    'social_media': {'hu': 'Közösségi média', 'en': 'Social media', 'ro': 'Social media'},
+    'edit_link': {'hu': 'Link szerkesztése', 'en': 'Edit link', 'ro': 'Editeaza: link'},
+    'link_hint': {'hu': 'Link vagy @felhasználó (pl. https://..., @user, user)', 'en': 'Link or @handle (e.g., https://..., @user, user)', 'ro': 'Link sau @handle (ex. https://..., @user, user)'},
+    'open_link': {'hu': 'Megnyitás', 'en': 'Open', 'ro': 'Deschide'},
+    'link_copied': {'hu': 'Link másolva.', 'en': 'Link copied.', 'ro': 'Link copiat.'},
+    'whats_on_your_mind': {'hu': 'Mi jár a fejedben?', 'en': "What's on your mind?", 'ro': 'La ce te gandesti?'},
+    'add_image': {'hu': 'Kép hozzáadása', 'en': 'Add image', 'ro': 'Adauga imagine'},
+    'gif_from_device': {'hu': 'GIF választása eszközről', 'en': 'Pick GIF from device', 'ro': 'Alege GIF din dispozitiv'},
+    'gif_from_url': {'hu': 'GIF beillesztése URL-ből', 'en': 'Paste GIF URL', 'ro': 'Introdu URL GIF'},
+    'gif_url_hint': {'hu': 'https://...', 'en': 'https://...', 'ro': 'https://...'},
+    'invalid_gif': {'hu': 'Csak GIF fájl választható.', 'en': 'Only GIF files are supported.', 'ro': 'Doar fișiere GIF sunt acceptate.'},
+    'invalid_gif_url': {'hu': 'Érvénytelen GIF hivatkozás.', 'en': 'Invalid GIF URL.', 'ro': 'URL GIF invalid.'},
+    'create_post': {'hu': 'Bejegyzés létrehozása', 'en': 'Create post', 'ro': 'Creeaza postare'},
+    'edit_post': {'hu': 'Bejegyzés szerkesztése', 'en': 'Edit post', 'ro': 'Editeaza postarea'},
+    'share_something': {'hu': 'Ossz meg valamit...', 'en': 'Share something...', 'ro': 'Imparte ceva...'},
+    'publish': {'hu': 'Közzététel', 'en': 'Publish', 'ro': 'Publica'},
+    'post_published': {'hu': 'Bejegyzés közzétéve.', 'en': 'Post published.', 'ro': 'Postare publicata.'},
+    'post_updated': {'hu': 'Bejegyzés frissítve.', 'en': 'Post updated.', 'ro': 'Postare actualizata.'},
+    'post_deleted': {'hu': 'Bejegyzés törölve.', 'en': 'Post deleted.', 'ro': 'Postare stearsa.'},
+    'delete_post_confirm': {
+      'hu': 'Biztosan törlöd a bejegyzést?',
+      'en': 'Are you sure you want to delete this post?',
+      'ro': 'Sigur vrei sa stergi aceasta postare?'
+    },
+    'gif_fetch_failed': {'hu': 'GIF letöltése sikertelen.', 'en': 'Failed to fetch GIF.', 'ro': 'Descărcarea GIF-ului a eșuat.'},
+    'edit_attachment_not_supported': {
+      'hu': 'A csatolmány módosítása szerkesztéskor nem támogatott.',
+      'en': 'Updating attachments while editing is not supported.',
+      'ro': 'Actualizarea atașamentelor în timpul editării nu este suportată.'
+    },
+    'feeling_activity': {'hu': 'Hangulat', 'en': 'Feeling', 'ro': 'Stare'},
+    'tag_friends': {'hu': 'Barátok megjelölése', 'en': 'Tag friends', 'ro': 'Eticheteaza prieteni'},
+    'check_in': {'hu': 'Helyszín bejelölése', 'en': 'Check in', 'ro': 'Check-in'},
+    'go_live': {'hu': 'Élő indítása', 'en': 'Go live', 'ro': 'Porneste live'},
+    'no_comments_yet': {'hu': 'Még nincs hozzászólás.', 'en': 'No comments yet.', 'ro': 'Nu exista comentarii.'},
+    'delete_comment_confirm': {
+      'hu': 'Biztosan törlöd a hozzászólást?',
+      'en': 'Delete this comment?',
+      'ro': 'Stergi acest comentariu?'
+    },
+    'comment_deleted': {'hu': 'Hozzászólás törölve.', 'en': 'Comment deleted.', 'ro': 'Comentariu sters.'},
+    'write_comment': {'hu': 'Írj egy hozzászólást...', 'en': 'Write a comment...', 'ro': 'Scrie un comentariu...'},
+    'share': {'hu': 'Megosztás', 'en': 'Share', 'ro': 'Distribuie'},
+    'like': {'hu': 'Tetszik', 'en': 'Like', 'ro': 'Imi place'},
+    'liked': {'hu': 'Tetszik', 'en': 'Liked', 'ro': 'Apreciat'},
+    'comment': {'hu': 'Hozzászólás', 'en': 'Comment', 'ro': 'Comentariu'},
+    'coming_soon': {'hu': 'Hamarosan', 'en': 'Coming soon', 'ro': 'In curand'},
+    'add_status': {'hu': 'Állapot hozzáadása', 'en': 'Add status', 'ro': 'Adauga stare'},
+    'reactions': {'hu': 'Reakciók', 'en': 'Reactions', 'ro': 'Reactii'},
+    'people_reacted': {
+      'hu': 'Reagálók listája',
+      'en': 'People who reacted',
+      'ro': 'Persoane care au reactionat'
+    },
+    'no_reactions_yet': {
+      'hu': 'Még nincs reakció.',
+      'en': 'No reactions yet.',
+      'ro': 'Nu exista reactii.'
+    },
+    'hide_replies': {'hu': 'Válaszok elrejtése', 'en': 'Hide replies', 'ro': 'Ascunde raspunsuri'},
+    'view_replies': {
+      'hu': 'Mutasd a %d választ',
+      'en': 'View %d replies',
+      'ro': 'Vezi %d raspunsuri'
+    },
+    'choose_reaction': {'hu': 'Válassz reakciót', 'en': 'Choose a reaction', 'ro': 'Alege o reactie'},
+    'reaction_like': {'hu': 'Tetszik', 'en': 'Like', 'ro': 'Imi place'},
+    'reaction_love': {'hu': 'Imádom', 'en': 'Love', 'ro': 'Iubesc'},
+    'reaction_care': {'hu': 'Ölelem', 'en': 'Care', 'ro': 'Imi pasa'},
+    'reaction_wow': {'hu': 'Hűha', 'en': 'Wow', 'ro': 'Uau'},
+    'reaction_haha': {'hu': 'Haha', 'en': 'Haha', 'ro': 'Haha'},
+    'reaction_sad': {'hu': 'Szomorú', 'en': 'Sad', 'ro': 'Trist'},
+    'reaction_angry': {'hu': 'Dühös', 'en': 'Angry', 'ro': 'Furios'},
+    'reply': {'hu': 'Válasz', 'en': 'Reply', 'ro': 'Raspunde'},
+    'editing_comment': {
+      'hu': 'Hozzászólás szerkesztése',
+      'en': 'Editing comment',
+      'ro': 'Editezi comentariul'
+    },
+    'replying_to': {
+      'hu': 'Válasz %s részére',
+      'en': 'Replying to %s',
+      'ro': 'Raspunzi lui %s'
+    },
+    'add_emoji': {'hu': 'Emoji hozzáadása', 'en': 'Add emoji', 'ro': 'Adauga emoji'},
+    'attach_gif': {'hu': 'GIF csatolása', 'en': 'Attach GIF', 'ro': 'Ataseaza GIF'},
+    'attach_photo': {'hu': 'Fotó csatolása', 'en': 'Attach photo', 'ro': 'Ataseaza fotografie'},
+    'attachment_added': {'hu': 'Csatolmány hozzáadva.', 'en': 'Attachment added.', 'ro': 'Atasament adaugat.'},
+    'attachment_removed': {'hu': 'Csatolmány eltávolítva.', 'en': 'Attachment removed.', 'ro': 'Atasament eliminat.'},
+    'uploading_attachment': {'hu': 'Csatolmány feltöltése...', 'en': 'Uploading attachment...', 'ro': 'Se incarca atasamentul...'},
+    'attachment_upload_failed': {
+      'hu': 'A csatolmány feltöltése sikertelen',
+      'en': 'Attachment upload failed',
+      'ro': 'Incarcarea atasamentului a esuat'
+    },
+    'use_current_location': {
+      'hu': 'Aktuális hely használata',
+      'en': 'Use current location',
+      'ro': 'Folosește locația curentă'
+    },
+    'set_location': {'hu': 'Hely megadása', 'en': 'Set location', 'ro': 'Setează locația'},
+    'location_hint': {'hu': 'Város, helyszín...', 'en': 'City, venue...', 'ro': 'Oraș, locație...'},
+    'location_fetch_failed': {
+      'hu': 'Nem sikerült a helyzetet lekérni.',
+      'en': 'Could not determine location.',
+      'ro': 'Nu s-a putut determina locația.'
+    },
+  };
+
+  static String t(BuildContext context, String key) {
+    final code = SettingsController.instance.locale?.languageCode ??
+        Localizations.localeOf(context).languageCode;
+    final m = _k[key];
+    if (m == null) return key;
+    // Default/fallback is Romanian without diacritics
+    final ro = _romanizeRo(m['ro'] ?? '');
+    if (code == 'hu') return m['hu'] ?? ro;
+    if (code == 'en') return m['en'] ?? ro;
+    return ro; // any other -> Romanian (romanized)
+  }
+}

--- a/lib/widgets/settings_screen.dart
+++ b/lib/widgets/settings_screen.dart
@@ -78,36 +78,15 @@ class SettingsScreen extends StatelessWidget {
                       controller.setThemePreference(value.first);
                     },
                   ),
-                  const SizedBox(height: 16),
-                  if (controller.themePreference != ThemePreference.scheduled)
-                    SegmentedButton<ThemeMode>(
-                      segments: [
-                        ButtonSegment(
-                          value: ThemeMode.system,
-                          label: Text(I18n.t(context, 'system')),
-                        ),
-                        ButtonSegment(
-                          value: ThemeMode.light,
-                          label: Text(I18n.t(context, 'light')),
-                        ),
-                        ButtonSegment(
-                          value: ThemeMode.dark,
-                          label: Text(I18n.t(context, 'dark')),
-                        ),
-                      ],
-                      selected: <ThemeMode>{controller.themeMode},
-                    onSelectionChanged: (value) {
-                      if (value.isEmpty) return;
-                      controller.setThemeMode(value.first);
-                    },
-                    )
-                  else
+                  if (controller.themePreference == ThemePreference.scheduled) ...[
+                    const SizedBox(height: 16),
                     _ScheduleRow(
                       start: controller.scheduledStart,
                       end: controller.scheduledEnd,
                       onStartTap: () => _pickSchedule(context, controller, true),
                       onEndTap: () => _pickSchedule(context, controller, false),
                     ),
+                  ],
                   const SizedBox(height: 16),
                   SwitchListTile.adaptive(
                     contentPadding: EdgeInsets.zero,

--- a/lib/widgets/settings_screen.dart
+++ b/lib/widgets/settings_screen.dart
@@ -1,0 +1,523 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../services/settings_service.dart';
+import '../utils/i18n.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  static const List<Color> _kAccentChoices = <Color>[
+    Color(0xFF6750A4),
+    Color(0xFF5E60CE),
+    Color(0xFF2F9FF8),
+    Color(0xFF0BA5A5),
+    Color(0xFF2BC760),
+    Color(0xFFFFB74D),
+    Color(0xFFFF7043),
+    Color(0xFFFF5C93),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = SettingsController.instance;
+    final theme = Theme.of(context);
+
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, _) {
+        final hasSeedColor = controller.seedColor != null;
+        final seedColor = controller.seedColor ?? theme.colorScheme.primary;
+        final languageItems = <DropdownMenuItem<Locale?>>[
+          DropdownMenuItem(value: null, child: Text(I18n.t(context, 'system'))),
+          const DropdownMenuItem(value: Locale('hu'), child: Text('Magyar')),
+          const DropdownMenuItem(value: Locale('en'), child: Text('English')),
+          const DropdownMenuItem(value: Locale('ro'), child: Text('Română')),
+        ];
+
+        return ListView(
+          padding: const EdgeInsets.fromLTRB(20, 24, 20, 36),
+          children: [
+            _SettingsHeader(seedColor: seedColor),
+            const SizedBox(height: 24),
+            _SettingsCard(
+              icon: Icons.palette_rounded,
+              title: I18n.t(context, 'appearance'),
+              description: I18n.t(context, 'appearance_hint'),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(I18n.t(context, 'theme_mode'), style: theme.textTheme.titleSmall),
+                  const SizedBox(height: 8),
+                  SegmentedButton<ThemePreference>(
+                    segments: [
+                      ButtonSegment(
+                        value: ThemePreference.system,
+                        label: Text(I18n.t(context, 'system')),
+                        icon: const Icon(Icons.settings_suggest_outlined),
+                      ),
+                      ButtonSegment(
+                        value: ThemePreference.light,
+                        label: Text(I18n.t(context, 'light')),
+                        icon: const Icon(Icons.light_mode_outlined),
+                      ),
+                      ButtonSegment(
+                        value: ThemePreference.dark,
+                        label: Text(I18n.t(context, 'dark')),
+                        icon: const Icon(Icons.nightlight_round_outlined),
+                      ),
+                      ButtonSegment(
+                        value: ThemePreference.scheduled,
+                        label: Text(I18n.t(context, 'scheduled')),
+                        icon: const Icon(Icons.schedule_rounded),
+                      ),
+                    ],
+                    selected: <ThemePreference>{controller.themePreference},
+                    onSelectionChanged: (value) {
+                      if (value.isEmpty) return;
+                      controller.setThemePreference(value.first);
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  if (controller.themePreference != ThemePreference.scheduled)
+                    SegmentedButton<ThemeMode>(
+                      segments: [
+                        ButtonSegment(
+                          value: ThemeMode.system,
+                          label: Text(I18n.t(context, 'system')),
+                        ),
+                        ButtonSegment(
+                          value: ThemeMode.light,
+                          label: Text(I18n.t(context, 'light')),
+                        ),
+                        ButtonSegment(
+                          value: ThemeMode.dark,
+                          label: Text(I18n.t(context, 'dark')),
+                        ),
+                      ],
+                      selected: <ThemeMode>{controller.themeMode},
+                    onSelectionChanged: (value) {
+                      if (value.isEmpty) return;
+                      controller.setThemeMode(value.first);
+                    },
+                    )
+                  else
+                    _ScheduleRow(
+                      start: controller.scheduledStart,
+                      end: controller.scheduledEnd,
+                      onStartTap: () => _pickSchedule(context, controller, true),
+                      onEndTap: () => _pickSchedule(context, controller, false),
+                    ),
+                  const SizedBox(height: 16),
+                  SwitchListTile.adaptive(
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(I18n.t(context, 'dynamic_color')),
+                    subtitle: Text(I18n.t(context, 'dynamic_color_hint')),
+                    value: controller.useDynamicColor,
+                    onChanged: (value) => controller.setUseDynamicColor(value),
+                  ),
+                  SwitchListTile.adaptive(
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(I18n.t(context, 'true_black')),
+                    value: controller.trueBlack,
+                    onChanged: (value) => controller.setTrueBlack(value),
+                  ),
+                  SwitchListTile.adaptive(
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(I18n.t(context, 'high_contrast')),
+                    value: controller.highContrast,
+                    onChanged: (value) => controller.setHighContrast(value),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(I18n.t(context, 'accent_color'), style: theme.textTheme.titleSmall),
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 12,
+                    children: [
+                      _AccentChoiceChip(
+                        color: seedColor,
+                        label: I18n.t(context, 'accent_default'),
+                        selected: !hasSeedColor,
+                        onSelected: (_) => controller.setSeedColor(null),
+                      ),
+                      for (final color in _kAccentChoices)
+                        _AccentChoiceChip(
+                          color: color,
+                          selected: hasSeedColor && controller.seedColor?.value == color.value,
+                          onSelected: (_) => controller.setSeedColor(color),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+            _SettingsCard(
+              icon: Icons.text_snippet_rounded,
+              title: I18n.t(context, 'reading_experience'),
+              description: I18n.t(context, 'reading_experience_hint'),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(I18n.t(context, 'text_scale'), style: theme.textTheme.titleSmall),
+                  Slider(
+                    value: controller.textScale,
+                    min: 0.85,
+                    max: 1.30,
+                    divisions: 9,
+                    label: controller.textScale.toStringAsFixed(2),
+                    onChanged: (value) => controller.setTextScale(value),
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(I18n.t(context, 'reduce_motion')),
+                      Switch.adaptive(
+                        value: controller.reduceMotion,
+                        onChanged: (value) => controller.setReduceMotion(value),
+                      ),
+                    ],
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(I18n.t(context, 'haptics')),
+                      Switch.adaptive(
+                        value: controller.haptics,
+                        onChanged: (value) => controller.setHaptics(value),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+            _SettingsCard(
+              icon: Icons.translate_rounded,
+              title: I18n.t(context, 'language'),
+              description: I18n.t(context, 'language_hint'),
+              child: DropdownButtonFormField<Locale?>(
+                value: controller.locale,
+                items: languageItems,
+                decoration: InputDecoration(
+                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(16)),
+                  filled: true,
+                  labelText: I18n.t(context, 'language'),
+                ),
+                onChanged: (locale) => controller.setLocale(locale),
+              ),
+            ),
+            const SizedBox(height: 24),
+            _SettingsCard(
+              icon: Icons.cloud_sync_rounded,
+              title: I18n.t(context, 'advanced'),
+              description: I18n.t(context, 'advanced_hint'),
+              child: Column(
+                children: [
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.download_rounded),
+                    title: Text(I18n.t(context, 'export_settings')),
+                    subtitle: Text(I18n.t(context, 'export_settings_hint')),
+                    onTap: () => _exportSettings(context, controller),
+                  ),
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.upload_rounded),
+                    title: Text(I18n.t(context, 'import_settings')),
+                    subtitle: Text(I18n.t(context, 'import_settings_hint')),
+                    onTap: () => _importSettings(context, controller),
+                  ),
+                  const Divider(height: 24),
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.restore_rounded),
+                    title: Text(I18n.t(context, 'reset')),
+                    subtitle: Text(I18n.t(context, 'reset_hint')),
+                    onTap: () => _confirmReset(context, controller),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  static Future<void> _pickSchedule(
+    BuildContext context,
+    SettingsController controller,
+    bool pickStart,
+  ) async {
+    final initial = pickStart ? controller.scheduledStart : controller.scheduledEnd;
+    final label = pickStart ? I18n.t(context, 'start_time') : I18n.t(context, 'end_time');
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: initial,
+      helpText: label,
+    );
+    if (picked == null) return;
+    final start = pickStart ? picked : controller.scheduledStart;
+    final end = pickStart ? controller.scheduledEnd : picked;
+    await controller.setThemeSchedule(start: start, end: end);
+  }
+
+  static Future<void> _exportSettings(
+    BuildContext context,
+    SettingsController controller,
+  ) async {
+    final json = await controller.exportSettingsJson();
+    await Clipboard.setData(ClipboardData(text: json));
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(I18n.t(context, 'settings_copied'))),
+    );
+  }
+
+  static Future<void> _importSettings(
+    BuildContext context,
+    SettingsController controller,
+  ) async {
+    final controllerText = TextEditingController();
+    final result = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(I18n.t(context, 'import_settings')),
+        content: TextField(
+          controller: controllerText,
+          minLines: 6,
+          maxLines: 12,
+          decoration: InputDecoration(hintText: I18n.t(context, 'paste_settings_hint')),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx), child: Text(I18n.t(context, 'cancel'))),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, controllerText.text.trim()),
+            child: Text(I18n.t(context, 'import_settings')),
+          ),
+        ],
+      ),
+    );
+    controllerText.dispose();
+    if (result == null || result.isEmpty) return;
+    try {
+      await controller.importSettingsJson(result);
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(I18n.t(context, 'import_success'))),
+      );
+    } catch (e) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('${I18n.t(context, 'import_failed')}: $e')),
+      );
+    }
+  }
+
+  static Future<void> _confirmReset(
+    BuildContext context,
+    SettingsController controller,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(I18n.t(context, 'reset')),
+        content: Text(I18n.t(context, 'reset_confirm')),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: Text(I18n.t(context, 'cancel'))),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(I18n.t(context, 'reset')),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await controller.resetToDefaults();
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(I18n.t(context, 'reset_done'))),
+    );
+  }
+}
+
+class _SettingsHeader extends StatelessWidget {
+  const _SettingsHeader({required this.seedColor});
+
+  final Color seedColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final gradient = LinearGradient(
+      colors: [seedColor, seedColor.withOpacity(0.45)],
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+    );
+    return Container(
+      decoration: BoxDecoration(
+        gradient: gradient,
+        borderRadius: BorderRadius.circular(28),
+        boxShadow: [
+          BoxShadow(color: seedColor.withOpacity(0.35), blurRadius: 30, offset: const Offset(0, 18)),
+        ],
+      ),
+      padding: const EdgeInsets.fromLTRB(24, 28, 24, 32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.tune_rounded, color: Colors.white.withOpacity(0.95), size: 32),
+          const SizedBox(height: 18),
+          Text(
+            I18n.t(context, 'settings'),
+            style: theme.textTheme.headlineMedium?.copyWith(
+              color: Colors.white,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            I18n.t(context, 'settings_tagline'),
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: Colors.white.withOpacity(0.85),
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SettingsCard extends StatelessWidget {
+  const _SettingsCard({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.child,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface.withOpacity(0.85),
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: Colors.white.withOpacity(0.08)),
+        boxShadow: [
+          BoxShadow(color: Colors.black.withOpacity(0.12), blurRadius: 22, offset: const Offset(0, 14)),
+        ],
+      ),
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primary.withOpacity(0.12),
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                padding: const EdgeInsets.all(10),
+                child: Icon(icon, color: theme.colorScheme.primary),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(title, style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700)),
+                    const SizedBox(height: 4),
+                    Text(description, style: theme.textTheme.bodySmall?.copyWith(color: theme.hintColor)),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 18),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _AccentChoiceChip extends StatelessWidget {
+  const _AccentChoiceChip({
+    required this.color,
+    this.label,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  final Color color;
+  final String? label;
+  final bool selected;
+  final ValueChanged<bool> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return FilterChip(
+      label: Text(label ?? '#${color.value.toRadixString(16).substring(2).toUpperCase()}'),
+      avatar: CircleAvatar(backgroundColor: color),
+      selected: selected,
+      onSelected: onSelected,
+      selectedColor: color.withOpacity(0.25),
+      checkmarkColor: theme.colorScheme.onPrimary,
+    );
+  }
+}
+
+class _ScheduleRow extends StatelessWidget {
+  const _ScheduleRow({
+    required this.start,
+    required this.end,
+    required this.onStartTap,
+    required this.onEndTap,
+  });
+
+  final TimeOfDay start;
+  final TimeOfDay end;
+  final VoidCallback onStartTap;
+  final VoidCallback onEndTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    String format(TimeOfDay tod) => tod.format(context);
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton.icon(
+            onPressed: onStartTap,
+            icon: const Icon(Icons.nights_stay_outlined),
+            label: Text('${I18n.t(context, 'start_time')} • ${format(start)}'),
+            style: OutlinedButton.styleFrom(padding: const EdgeInsets.symmetric(vertical: 12)),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: OutlinedButton.icon(
+            onPressed: onEndTap,
+            icon: const Icon(Icons.sunny_snowing),
+            label: Text('${I18n.t(context, 'end_time')} • ${format(end)}'),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: theme.colorScheme.primary,
+              padding: const EdgeInsets.symmetric(vertical: 12),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/server/public/api/comment_media.php
+++ b/server/public/api/comment_media.php
@@ -1,0 +1,78 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+use App\Core\Response;
+use App\Repositories\UserRepository;
+use App\Repositories\TokenRepository;
+use App\Services\AuthService;
+use App\Core\Database;
+
+$config = require __DIR__ . '/../../config/config.php';
+$auth = new AuthService(new UserRepository(), new TokenRepository(), $config['auth']['token_ttl'] ?? (7*24*3600));
+
+$authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? ($_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '');
+if ($authHeader === '' && function_exists('getallheaders')) {
+    $headers = getallheaders();
+    if (isset($headers['Authorization'])) {
+        $authHeader = $headers['Authorization'];
+    }
+}
+
+$user = $auth->authenticate($authHeader);
+if (!$user) {
+    Response::json(['error' => 'Unauthorized'], 401);
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    Response::json(['error' => 'Method Not Allowed'], 405);
+}
+
+$publicDir = realpath(__DIR__ . '/..');
+$uploadsDir = $publicDir . DIRECTORY_SEPARATOR . 'uploads';
+$commentsDir = $uploadsDir . DIRECTORY_SEPARATOR . 'comments';
+if (!is_dir($uploadsDir)) {
+    mkdir($uploadsDir, 0755, true);
+}
+if (!is_dir($commentsDir)) {
+    mkdir($commentsDir, 0755, true);
+}
+
+if (!isset($_FILES['file'])) {
+    Response::json(['error' => 'No file uploaded'], 400);
+}
+
+$file = $_FILES['file'];
+if (!is_uploaded_file($file['tmp_name'])) {
+    Response::json(['error' => 'Upload failed'], 400);
+}
+
+$original = $file['name'] ?: 'attachment';
+$ext = strtolower(pathinfo($original, PATHINFO_EXTENSION));
+if (!in_array($ext, ['jpg', 'jpeg', 'png', 'gif', 'webp'], true)) {
+    Response::json(['error' => 'Unsupported file type'], 400);
+}
+
+$safe = preg_replace('/[^a-zA-Z0-9_\.-]/', '_', strtolower($original));
+$safe = substr($safe, -80);
+$timestamp = time();
+$finalName = $timestamp . '_' . $safe;
+$targetPath = $commentsDir . DIRECTORY_SEPARATOR . $finalName;
+
+if (!move_uploaded_file($file['tmp_name'], $targetPath)) {
+    Response::json(['error' => 'Failed to store file'], 500);
+}
+
+$publicUrlBase = $config['app']['public_base_url'] ?? '';
+if ($publicUrlBase === '') {
+    // Attempt to build from current request
+    $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+    $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+    $path = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/\\');
+    $publicUrlBase = $scheme . '://' . $host . $path;
+}
+
+$relative = $publicUrlBase . '/uploads/comments/' . $finalName;
+
+Response::json([
+    'url' => $relative,
+]);

--- a/server/public/api/comments.php
+++ b/server/public/api/comments.php
@@ -1,0 +1,101 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+use App\Core\Response;
+use App\Repositories\UserRepository;
+use App\Repositories\TokenRepository;
+use App\Services\AuthService;
+use App\Core\Database;
+
+$config = require __DIR__ . '/../../config/config.php';
+$auth = new AuthService(new UserRepository(), new TokenRepository(), $config['auth']['token_ttl'] ?? (7*24*3600));
+$pdo = Database::pdo();
+
+switch ($_SERVER['REQUEST_METHOD']) {
+    case 'GET':
+        $postId = isset($_GET['post_id']) ? (int)$_GET['post_id'] : 0;
+        if ($postId <= 0) Response::json(['error' => 'post_id required'], 400);
+        $sql = 'SELECT c.id, c.post_id, c.user_id, c.parent_id, c.content, c.created_at, u.full_name AS user_name, u.avatar_url AS user_avatar
+                FROM comments c
+                JOIN `user` u ON u.id = c.user_id
+                WHERE c.post_id = ?
+                ORDER BY c.id ASC';
+        $st = $pdo->prepare($sql);
+        $st->execute([$postId]);
+        $rows = $st->fetchAll() ?: [];
+        Response::json(['comments' => $rows]);
+        break;
+    case 'POST':
+        $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? ($_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '');
+        if ($authHeader === '' && function_exists('getallheaders')) { $h = getallheaders(); if (isset($h['Authorization'])) $authHeader = $h['Authorization']; }
+        $user = $auth->authenticate($authHeader);
+        if (!$user) Response::json(['error' => 'Unauthorized'], 401);
+        $body = read_json_body();
+        $postId = (int)($body['post_id'] ?? 0);
+        $parentId = isset($body['parent_id']) ? (int)$body['parent_id'] : null;
+        $content = trim((string)($body['content'] ?? ''));
+        if ($postId <= 0 || $content === '') Response::json(['error' => 'post_id and content required'], 400);
+        if ($parentId !== null && $parentId > 0) {
+            // Validate parent belongs to same post
+            $chk = $pdo->prepare('SELECT post_id FROM comments WHERE id=? LIMIT 1');
+            $chk->execute([$parentId]);
+            $row = $chk->fetch();
+            if (!$row || (int)$row['post_id'] !== $postId) {
+                Response::json(['error' => 'Invalid parent_id'], 400);
+            }
+        } else {
+            $parentId = null;
+        }
+        $ins = $pdo->prepare('INSERT INTO comments (post_id, user_id, parent_id, content) VALUES (?, ?, ?, ?)');
+        $ins->execute([$postId, $user->id, $parentId, $content]);
+        $id = (int)$pdo->lastInsertId();
+        $sel = $pdo->prepare('SELECT c.id, c.post_id, c.user_id, c.parent_id, c.content, c.created_at, u.full_name AS user_name, u.avatar_url AS user_avatar
+                              FROM comments c JOIN `user` u ON u.id = c.user_id WHERE c.id = ?');
+        $sel->execute([$id]);
+        $row = $sel->fetch();
+        Response::json(['comment' => $row], 201);
+        break;
+    case 'DELETE':
+        $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? ($_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '');
+        if ($authHeader === '' && function_exists('getallheaders')) { $h = getallheaders(); if (isset($h['Authorization'])) $authHeader = $h['Authorization']; }
+        $user = $auth->authenticate($authHeader);
+        if (!$user) Response::json(['error' => 'Unauthorized'], 401);
+        $commentId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+        if ($commentId <= 0) Response::json(['error' => 'id required'], 400);
+        // Allow delete if owner of comment
+        $s = $pdo->prepare('SELECT user_id FROM comments WHERE id=? LIMIT 1');
+        $s->execute([$commentId]);
+        $row = $s->fetch();
+        if (!$row) Response::json(['error' => 'Not found'], 404);
+        if ((int)$row['user_id'] !== (int)$user->id) {
+            Response::json(['error' => 'Forbidden'], 403);
+        }
+        $d = $pdo->prepare('DELETE FROM comments WHERE id=?');
+        $d->execute([$commentId]);
+        Response::json(['deleted' => true]);
+        break;
+    case 'PATCH':
+        $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? ($_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '');
+        if ($authHeader === '' && function_exists('getallheaders')) { $h = getallheaders(); if (isset($h['Authorization'])) $authHeader = $h['Authorization']; }
+        $user = $auth->authenticate($authHeader);
+        if (!$user) Response::json(['error' => 'Unauthorized'], 401);
+        $body = read_json_body();
+        $commentId = (int)($body['id'] ?? 0);
+        $content = trim((string)($body['content'] ?? ''));
+        if ($commentId <= 0 || $content === '') Response::json(['error' => 'id and content required'], 400);
+        $sel = $pdo->prepare('SELECT user_id FROM comments WHERE id=? LIMIT 1');
+        $sel->execute([$commentId]);
+        $row = $sel->fetch();
+        if (!$row) Response::json(['error' => 'Not found'], 404);
+        if ((int)$row['user_id'] !== (int)$user->id) Response::json(['error' => 'Forbidden'], 403);
+        $upd = $pdo->prepare('UPDATE comments SET content=?, updated_at=CURRENT_TIMESTAMP WHERE id=?');
+        $upd->execute([$content, $commentId]);
+        $out = $pdo->prepare('SELECT c.id, c.post_id, c.user_id, c.parent_id, c.content, c.created_at, c.updated_at, u.full_name AS user_name, u.avatar_url AS user_avatar
+                              FROM comments c JOIN `user` u ON u.id = c.user_id WHERE c.id = ?');
+        $out->execute([$commentId]);
+        $comment = $out->fetch();
+        Response::json(['comment' => $comment]);
+        break;
+    default:
+        Response::json(['error' => 'Method Not Allowed'], 405);
+}

--- a/server/public/api/reactions.php
+++ b/server/public/api/reactions.php
@@ -1,0 +1,90 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+use App\Core\Response;
+use App\Repositories\UserRepository;
+use App\Repositories\TokenRepository;
+use App\Services\AuthService;
+use App\Core\Database;
+
+$config = require __DIR__ . '/../../config/config.php';
+$auth = new AuthService(new UserRepository(), new TokenRepository(), $config['auth']['token_ttl'] ?? (7*24*3600));
+$pdo = Database::pdo();
+
+switch ($_SERVER['REQUEST_METHOD']) {
+    case 'GET':
+        $postId = isset($_GET['post_id']) ? (int)$_GET['post_id'] : 0;
+        if ($postId <= 0) Response::json(['error' => 'post_id required'], 400);
+
+        $stmt = $pdo->prepare('SELECT type, COUNT(*) as cnt FROM reactions WHERE post_id = ? GROUP BY type');
+        $stmt->execute([$postId]);
+        $counts = [];
+        foreach ($stmt->fetchAll() ?: [] as $r) {
+            $counts[$r['type']] = (int) $r['cnt'];
+        }
+
+        $listStmt = $pdo->prepare('SELECT r.type, u.full_name, u.username, u.avatar_url
+                                    FROM reactions r
+                                    JOIN `user` u ON u.id = r.user_id
+                                    WHERE r.post_id = ?
+                                    ORDER BY r.id DESC');
+        $listStmt->execute([$postId]);
+        $people = [];
+        foreach ($listStmt->fetchAll() ?: [] as $row) {
+            $people[] = [
+                'type' => $row['type'],
+                'name' => $row['full_name'] ?: ($row['username'] ?: 'User'),
+                'username' => $row['username'],
+                'avatar_url' => $row['avatar_url'],
+            ];
+        }
+
+        $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? ($_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '');
+        $user = $auth->authenticate($authHeader);
+        $userReaction = null;
+        if ($user) {
+            $s = $pdo->prepare('SELECT type FROM reactions WHERE post_id=? AND user_id=? LIMIT 1');
+            $s->execute([$postId, $user->id]);
+            $row = $s->fetch();
+            $userReaction = $row['type'] ?? null;
+        }
+
+        Response::json([
+            'counts' => $counts,
+            'user_reaction' => $userReaction,
+            'reactions' => $people,
+        ]);
+        break;
+    case 'POST':
+        $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? ($_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? '');
+        if ($authHeader === '' && function_exists('getallheaders')) { $h = getallheaders(); if (isset($h['Authorization'])) $authHeader = $h['Authorization']; }
+        $user = $auth->authenticate($authHeader);
+        if (!$user) Response::json(['error' => 'Unauthorized'], 401);
+        $body = read_json_body();
+        $postId = (int)($body['post_id'] ?? 0);
+        $type = preg_replace('/[^a-z]/', '', strtolower($body['type'] ?? 'like'));
+        if ($postId <= 0) Response::json(['error' => 'post_id required'], 400);
+        // toggle: if existing with same type -> delete; if existing other type -> update; else insert
+        $s = $pdo->prepare('SELECT id, type FROM reactions WHERE post_id=? AND user_id=? LIMIT 1');
+        $s->execute([$postId, $user->id]);
+        $row = $s->fetch();
+        if ($row) {
+            if ($row['type'] === $type) {
+                $d = $pdo->prepare('DELETE FROM reactions WHERE id=?');
+                $d->execute([(int)$row['id']]);
+                Response::json(['reacted' => false]);
+            } else {
+                $u = $pdo->prepare('UPDATE reactions SET type=? WHERE id=?');
+                $u->execute([$type, (int)$row['id']]);
+                Response::json(['reacted' => true, 'type' => $type]);
+            }
+        } else {
+            $i = $pdo->prepare('INSERT INTO reactions (post_id, user_id, type) VALUES (?, ?, ?)');
+            $i->execute([$postId, $user->id, $type]);
+            Response::json(['reacted' => true, 'type' => $type]);
+        }
+        break;
+    default:
+        Response::json(['error' => 'Method Not Allowed'], 405);
+}
+


### PR DESCRIPTION
## Summary
- refresh the feed card presentation with vibe-backed post bodies, inline meta chips, reaction detail sheets, and media-capable comments
- extend the PHP API and Dart service layer to support comment media uploads, reaction listings, and richer comment mutations
- deliver a futuristic 2025-ready settings hub with theme scheduling, accent controls, export/import utilities, and updated translations

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db79580cc88322bc1b94e869708016